### PR TITLE
Allow environment variables to be loaded from a file

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,47 @@
+# All variables in this file are optional or have default values in the config file. The development server will be able to run without an .env file
+# However some features might not work, for instance sending emails without Mailjet creds.
+
+# Database URL (default : the "mobilic" DB on your local psql server)
+DATABASE_URL=
+
+# FranceConnect url and token
+FC_CLIENT_SECRET=
+FC_URL=
+
+FRONTEND_URL=
+
+# Credentials of the GCP service account used to edit google drive spreadsheets
+GOOGLE_CLIENT_CERT_URL=
+GOOGLE_CLIENT_EMAIL=
+GOOGLE_PRIVATE_KEY=
+GOOGLE_PRIVATE_KEY_ID=
+GOOGLE_PROJECT_NAME=
+GOOGLE_CLIENT_ID=
+
+# Key used to sign Excel files download by company admins
+HMAC_SIGNING_KEY=
+
+# Webhook used to create a Trello card upon signup of a new company
+INTEGROMAT_COMPANY_SIGNUP_WEBHOOK=
+
+JWT_SECRET_KEY=
+
+# Mailjet credentials
+MAILJET_API_KEY=
+MAILJET_API_SECRET=
+
+# Webhook to send errors/alerts to Mattermost
+MATTERMOST_WEBHOOK=
+
+MOBILIC_ENV=
+
+# Credentials expected in request body for execution of a service (GCP scheduler uses this)
+MOBILIC_SERVICE_ACTOR_TOKEN=
+
+# Credentials used to send logs to OVH log solution
+OVH_LDP_TOKEN=
+
+# URL to send Sentry alerts to
+SENTRY_URL=
+
+SIREN_API_KEY=

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,9 @@
 # python virtual env
 venv
 
+# Environment variables file
+.env
+
 # IDE files
 .idea
 

--- a/README.md
+++ b/README.md
@@ -36,9 +36,16 @@ Exécuter le script d'installation depuis la racine du projet :
 * `FRONTEND_URL` : URL du serveur front (utilisé pour générer des liens dans des mails par exemple)
 * `JWT_SECRET_KEY` : secret utilisé pour générer les jetons d'authentification. Facultatif.
 
-Ne sont listées ici que les variables les plus importantes. En outre il existe d'autres variables de configuration directement définies dans le fichier [config.py](./config.py).
+Ne sont listées ici que les variables les plus importantes. L'intégralité des variables de configuration peut être trouvée dans le fichier [config.py](./config.py).
 
-⚠️ Attention : les fichiers de type `.env` ne sont pas pris en charge (pour l'instant).
+Il possible de définir les variables d'environnement à partir d'un fichier texte qu'il faut rajouter à la racine du projet. Il faut ensuite passer le nom du fichier à l'application via la variable `DOTENV_FILE`.
+
+```
+DOTENV_FILE=.env flask run ...
+```
+
+Un [fichier d'exemple](./.env.example) détaille la structure attendue pour ce fichier. 
+
 
 ## Démarrage du serveur de développement
 

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ Exécuter le script d'installation depuis la racine du projet :
 
 Ne sont listées ici que les variables les plus importantes. L'intégralité des variables de configuration peut être trouvée dans le fichier [config.py](./config.py).
 
-Il possible de définir les variables d'environnement à partir d'un fichier texte qu'il faut rajouter à la racine du projet. Il faut ensuite passer le nom du fichier à l'application via la variable `DOTENV_FILE`.
+Il est possible de définir les variables d'environnement à partir d'un fichier texte qu'il faut rajouter à la racine du projet. Il faut ensuite passer le nom du fichier à l'application via la variable `DOTENV_FILE`.
 
 ```
 DOTENV_FILE=.env flask run ...

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -9,6 +9,7 @@ from apispec import APISpec
 from apispec.ext.marshmallow import MarshmallowPlugin
 
 import config
+from config import MOBILIC_ENV
 from app.helpers.db import SQLAlchemyWithStrongRefSession
 from app.helpers.mail import Mailer
 from app.helpers.siren import SirenAPIClient
@@ -30,8 +31,7 @@ app.config.update(
 
 docs = FlaskApiSpec(app)
 
-env = os.environ.get("MOBILIC_ENV", "dev")
-app.config.from_object(getattr(config, f"{env.capitalize()}Config"))
+app.config.from_object(getattr(config, f"{MOBILIC_ENV.capitalize()}Config"))
 
 siren_api_client = SirenAPIClient(app.config["SIREN_API_KEY"])
 

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -45,7 +45,7 @@ if app.config["SENTRY_URL"]:
     sentry_sdk.init(
         dsn=app.config["SENTRY_URL"],
         integrations=[FlaskIntegration()],
-        environment=env,
+        environment=MOBILIC_ENV,
     )
 
 db = SQLAlchemyWithStrongRefSession(
@@ -67,7 +67,7 @@ from app.helpers import logging
 
 @app.before_first_request
 def configure_app():
-    if env == "prod":
+    if MOBILIC_ENV == "prod":
         db.engine.dispose()
 
 

--- a/app/controllers/company.py
+++ b/app/controllers/company.py
@@ -147,7 +147,7 @@ class CompanySignUp(graphene.Mutation):
                     f"Creation of Trello card for {company} failed with error : {e}"
                 )
 
-        if os.environ.get("GOOGLE_PRIVATE_KEY"):
+        if app.config["GOOGLE_PRIVATE_KEY"]:
             # Add new company to spreadsheet
             try:
                 add_company_to_spreadsheet(company, current_user)

--- a/app/helpers/google_drive.py
+++ b/app/helpers/google_drive.py
@@ -1,7 +1,8 @@
-import os
 from googleapiclient.discovery import build
 from google.auth.transport.requests import Request
 from google.oauth2 import service_account
+
+from app import app
 
 
 def auth_to_google_sheets():
@@ -22,17 +23,17 @@ def auth_to_google_sheets():
                     "auth_uri": "https://accounts.google.com/o/oauth2/auth",
                     "token_uri": "https://oauth2.googleapis.com/token",
                     "auth_provider_x509_cert_url": "https://www.googleapis.com/oauth2/v1/certs",
-                    "client_x509_cert_url": os.environ.get(
+                    "client_x509_cert_url": app.config[
                         "GOOGLE_CLIENT_CERT_URL"
-                    ),
-                    "client_email": os.environ.get("GOOGLE_CLIENT_EMAIL"),
+                    ],
+                    "client_email": app.config["GOOGLE_CLIENT_EMAIL"],
                     "type": "service_account",
-                    "project_id": os.environ.get("GOOGLE_PROJECT_NAME"),
-                    "private_key_id": os.environ.get("GOOGLE_PRIVATE_KEY_ID"),
-                    "private_key": os.environ.get(
-                        "GOOGLE_PRIVATE_KEY"
-                    ).replace("\\n", "\n"),
-                    "client_id": os.environ.get("GOOGLE_CLIENT_ID"),
+                    "project_id": app.config["GOOGLE_PROJECT_NAME"],
+                    "private_key_id": app.config["GOOGLE_PRIVATE_KEY_ID"],
+                    "private_key": app.config["GOOGLE_PRIVATE_KEY"].replace(
+                        "\\n", "\n"
+                    ),
+                    "client_id": app.config["GOOGLE_CLIENT_ID"],
                 }
             )
 

--- a/app/helpers/logging.py
+++ b/app/helpers/logging.py
@@ -1,5 +1,3 @@
-import os
-
 import logging
 import requests
 from marshmallow import fields
@@ -10,6 +8,7 @@ from logging_ldp.handlers import LDPGELFTCPSocketHandler
 from logging_ldp.schemas import LDPSchema
 
 from app import app
+from config import MOBILIC_ENV
 from app.helpers.authentication import current_user
 from app.helpers.errors import MobilicError
 
@@ -52,7 +51,7 @@ def post_to_mattermost(
             channel=app.config["MATTERMOST_PRIMARY_LOG_CHANNEL"]
             if not is_secondary
             else app.config["MATTERMOST_SECONDARY_LOG_CHANNEL"],
-            username=f"Mobilic backend - {os.environ.get('MOBILIC_ENV', 'test').capitalize()}",
+            username=f"Mobilic backend - {MOBILIC_ENV.capitalize()}",
             icon_emoji=emoji,
             attachments=[
                 dict(

--- a/app/helpers/mail.py
+++ b/app/helpers/mail.py
@@ -1,6 +1,5 @@
 from mailjet_rest import Client
 import jwt
-import os
 from cached_property import cached_property
 from flask import render_template
 from datetime import datetime, date
@@ -12,8 +11,6 @@ from app.helpers.mail_type import EmailType
 
 SENDER_ADDRESS = "mobilic@beta.gouv.fr"
 SENDER_NAME = "Mobilic"
-
-env = os.environ.get("MOBILIC_ENV", "dev")
 
 
 class MailjetSuccess:

--- a/config.py
+++ b/config.py
@@ -5,6 +5,8 @@ import os
 if os.environ.get("DOTENV_FILE", False):
     load_dotenv(os.environ.get("DOTENV_FILE"))
 
+MOBILIC_ENV = os.environ.get("MOBILIC_ENV", "dev")
+
 
 class Config:
     SQLALCHEMY_DATABASE_URI = os.environ.get(

--- a/config.py
+++ b/config.py
@@ -1,5 +1,9 @@
 from datetime import timedelta
+from dotenv import load_dotenv
 import os
+
+if os.environ.get("DOTENV_FILE", False):
+    load_dotenv(os.environ.get("DOTENV_FILE"))
 
 
 class Config:
@@ -59,6 +63,12 @@ class Config:
             "MIN_MINUTES_BETWEEN_INVITATION_EMAILS", 60 * 24
         )
     )
+    GOOGLE_CLIENT_CERT_URL = os.environ.get("GOOGLE_CLIENT_CERT_URL", None)
+    GOOGLE_CLIENT_EMAIL = os.environ.get("GOOGLE_CLIENT_EMAIL", None)
+    GOOGLE_PRIVATE_KEY = os.environ.get("GOOGLE_PRIVATE_KEY", None)
+    GOOGLE_PRIVATE_KEY_ID = os.environ.get("GOOGLE_PRIVATE_KEY_ID", None)
+    GOOGLE_PROJECT_NAME = os.environ.get("GOOGLE_PROJECT_NAME", None)
+    GOOGLE_CLIENT_ID = os.environ.get("GOOGLE_CLIENT_ID", None)
 
 
 class DevConfig(Config):


### PR DESCRIPTION
Cette PR permet en développement local de charger les variables d'environnement depuis un fichier texte (`.env` ou autre), situé à la racine du projet.

L'application sait quel fichier charger à partir de la variable `DOTENV_FILE`. Ce qui permet d'avoir plusieurs fichiers environnements sur son poste et de passer de l'un à l'autre facilement.