### PR TITLE
Standardize errors returned by REST endpoints

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -1,8 +1,7 @@
-from flask import Flask
+from flask import Flask, jsonify
 from flask_apispec import FlaskApiSpec
 from flask_migrate import Migrate
 from flask_cors import CORS
-import os
 import sentry_sdk
 from sentry_sdk.integrations.flask import FlaskIntegration
 from apispec import APISpec
@@ -11,6 +10,7 @@ from apispec.ext.marshmallow import MarshmallowPlugin
 import config
 from config import MOBILIC_ENV
 from app.helpers.db import SQLAlchemyWithStrongRefSession
+from app.helpers.errors import MobilicError
 from app.helpers.siren import SirenAPIClient
 from app.helpers.request_parser import CustomRequestParser
 from app.templates.filters import JINJA_CUSTOM_FILTERS
@@ -127,6 +127,9 @@ def compute_usage_stats():
     )
 
 
+from app.controllers.misc import *
+
+
 @app.route("/services/send-onboarding-emails", methods=["POST"])
 @service_decorator
 def send_onboarding_emails():
@@ -138,4 +141,11 @@ def send_onboarding_emails():
     return "C'est fait", 200
 
 
-from app.controllers.misc import *
+@app.errorhandler(MobilicError)
+def handle_error(error):
+    app.logger.exception(error)
+    error.extensions.pop("code")
+    error_payload = {"error": error.message, "error_code": error.code}
+    if error.extensions:
+        error_payload["details"] = error.extensions
+    return jsonify(error_payload), error.http_status_code

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -2,6 +2,7 @@ from flask import Flask, jsonify
 from flask_apispec import FlaskApiSpec
 from flask_migrate import Migrate
 from flask_cors import CORS
+from werkzeug.exceptions import HTTPException
 import sentry_sdk
 from sentry_sdk.integrations.flask import FlaskIntegration
 from apispec import APISpec
@@ -149,3 +150,17 @@ def handle_error(error):
     if error.extensions:
         error_payload["details"] = error.extensions
     return jsonify(error_payload), error.http_status_code
+
+
+@app.errorhandler(HTTPException)
+def handle_error(error):
+    app.logger.exception(error)
+    return (
+        jsonify(
+            {
+                "error": error.description,
+                "error_code": error.name.upper().replace(" ", "_"),
+            }
+        ),
+        error.code,
+    )

--- a/app/controllers/contacts.py
+++ b/app/controllers/contacts.py
@@ -51,4 +51,3 @@ def subscribe_to_newsletter(list, email=None):
     else:
         mailer.subscribe_email_to_contact_list(email, list)
     return jsonify({"success": True}), 200
-

--- a/app/controllers/control.py
+++ b/app/controllers/control.py
@@ -5,9 +5,9 @@ from app.helpers.authorization import (
     authenticated_and_active,
     current_user,
 )
+from app.helpers.errors import BadRequestError
 from app.helpers.xls import (
     retrieve_and_verify_signature,
-    IntegrityVerificationError,
 )
 from app.models import UserReadToken
 
@@ -27,10 +27,9 @@ def generate_read_token():
 @control_blueprint.route("/verify-xlsx-signature", methods=["POST"])
 def verify_xlsx_signature():
     if FILE_NAME not in request.files:
-        return jsonify({"error": "MISSING_FILE"}), 400
+        raise BadRequestError(
+            f"Could not find file with name {FILE_NAME} in request"
+        )
     file = request.files[FILE_NAME]
-    try:
-        retrieve_and_verify_signature(file)
-        return {"success": True}
-    except IntegrityVerificationError as e:
-        return jsonify({"error": e.code})
+    retrieve_and_verify_signature(file)
+    return {"success": True}

--- a/app/helpers/authentication.py
+++ b/app/helpers/authentication.py
@@ -356,14 +356,13 @@ def rest_refresh_token():
         tokens = _refresh_token()
         return jsonify(tokens), 200
     except AuthenticationError as e:
-        app.logger.exception(e)
 
         @after_this_request
         def unset_cookies(response):
             unset_auth_cookies(response)
             return response
 
-        return jsonify({"error": e.message}), 401
+        raise
 
 
 @wrap_jwt_errors
@@ -379,12 +378,8 @@ def rest_logout():
         unset_auth_cookies(response)
         return response
 
-    try:
-        logout()
-        return jsonify({"success": True}), 200
-    except AuthenticationError as e:
-        app.logger.exception(e)
-        return jsonify({"error": e.message}), 401
+    logout()
+    return jsonify({"success": True}), 200
 
 
 @jwt_refresh_token_required

--- a/app/helpers/errors.py
+++ b/app/helpers/errors.py
@@ -45,7 +45,7 @@ class InvalidParamsError(MobilicError):
 
 
 class InternalError(MobilicError):
-    code = "INTERNAL_ERROR"
+    code = "INTERNAL_SERVER_ERROR"
 
 
 class AuthenticationError(MobilicError):

--- a/app/helpers/errors.py
+++ b/app/helpers/errors.py
@@ -12,6 +12,8 @@ class MobilicError(GraphQLError, ABC):
     def code(self):
         pass
 
+    http_status_code = 500
+
     default_should_alert_team = True
     default_message = "Error"
 
@@ -31,8 +33,15 @@ class MobilicError(GraphQLError, ABC):
         return dict(message=self.message, extensions=self.extensions)
 
 
+class BadRequestError(MobilicError):
+    code = "BAD_REQUEST"
+    default_message = "Invalid request"
+    http_status_code = 400
+
+
 class InvalidParamsError(MobilicError):
     code = "INVALID_INPUTS"
+    http_status_code = 422
 
 
 class InternalError(MobilicError):
@@ -42,10 +51,12 @@ class InternalError(MobilicError):
 class AuthenticationError(MobilicError):
     code = "AUTHENTICATION_ERROR"
     default_should_alert_team = False
+    http_status_code = 401
 
 
 class AuthorizationError(MobilicError):
     code = "AUTHORIZATION_ERROR"
+    http_status_code = 403
 
 
 class SirenAlreadySignedUpError(MobilicError):

--- a/app/helpers/oauth/__init__.py
+++ b/app/helpers/oauth/__init__.py
@@ -10,12 +10,18 @@ from app.helpers.authentication import (
     current_user,
     wrap_jwt_errors,
 )
+from app.helpers.errors import MobilicError
 from app.models import User
 from app.helpers.oauth.models import (
     OAuth2AuthorizationCode,
     OAuth2Client,
     OAuth2Token,
 )
+
+
+class AuthorizationRequestParsingError(MobilicError):
+    code = "AUTHORIZATION_PARSING_ERROR"
+    http_status_code = 400
 
 
 class AuthorizationCodeGrant(grants.AuthorizationCodeGrant):
@@ -107,9 +113,8 @@ def parse_authorization_request():
 
     except Exception as e:
         app.logger.exception(e)
-        return make_response(
-            jsonify({"error": "Invalid or missing client id or redirect uri"}),
-            400,
+        raise AuthorizationRequestParsingError(
+            "Invalid or missing client id or redirect uri"
         )
 
     return jsonify({"client_name": client.name, "redirect_uri": redirect_uri})

--- a/app/helpers/request_parser.py
+++ b/app/helpers/request_parser.py
@@ -1,17 +1,16 @@
 from webargs.flaskparser import FlaskParser
 from flask import abort, jsonify
 
+from app.helpers.errors import InvalidParamsError, BadRequestError
+
 
 class CustomRequestParser(FlaskParser):
     def handle_error(
         self, error, req, schema, *, error_status_code, error_headers
     ):
-        status_code = error_status_code or self.DEFAULT_VALIDATION_STATUS
-        response = jsonify({"parsing_error": error.messages})
-        response.status_code = status_code
-        abort(response)
+        raise InvalidParamsError(
+            message="Parsing failed", extensions=error.messages
+        )
 
     def _handle_invalid_json_error(self, error, req, *args, **kwargs):
-        response = jsonify({"parsing_error": error.messages})
-        response.status_code = 400
-        abort(response)
+        raise BadRequestError("Invalid json")

--- a/app/helpers/xls.py
+++ b/app/helpers/xls.py
@@ -1,5 +1,6 @@
 from collections import defaultdict
 from flask import send_file, after_this_request
+from abc import ABC
 from xlsxwriter import Workbook
 from datetime import timedelta
 from io import BytesIO
@@ -8,7 +9,7 @@ import hashlib
 from zipfile import ZipFile, ZIP_DEFLATED
 from defusedxml.ElementTree import parse
 
-from app import app
+from app import app, MobilicError
 from app.models.activity import ActivityType
 from app.helpers.time import to_fr_tz
 
@@ -42,8 +43,8 @@ light_red_hex = "#efaca6"
 very_light_red_hex = "#fcb4b4"
 
 
-class IntegrityVerificationError(Exception):
-    code = None
+class IntegrityVerificationError(MobilicError, ABC):
+    pass
 
 
 class InvalidXlsxFormat(IntegrityVerificationError):


### PR DESCRIPTION
Il y a de plus en plus d'endpoints REST dans l'application. Cette PR uniformise la structure des erreurs retournées par tous ces endpoints. Une erreur contient :

* un champ obligatoire `error` avec le descriptif de l'erreur
* un champ obligatoire `error_code` avec le code de l'erreur (texte)
* un champ facultatif `details`avec des informations supplémentaires sur l'erreur