### PR TITLE
Visualize missions validated by admin

### DIFF
--- a/app/data_access/company.py
+++ b/app/data_access/company.py
@@ -98,9 +98,9 @@ class CompanyOutput(BaseSQLAlchemyObjectType):
             required=False,
             description="Nombre maximal de missions retournées, par ordre de récence.",
         ),
-        only_non_validated_missions=graphene.Boolean(
+        only_ended_missions=graphene.Boolean(
             required=False,
-            description="Ne retourne que les missions qui n'ont pas encore été validées par le gestionnaire. Par défaut l'option n'est pas activée.",
+            description="Ne retourne que les missions qui sont terminées par tous leurs utilisateurs.",
         ),
     )
     vehicles = graphene.List(
@@ -169,7 +169,7 @@ class CompanyOutput(BaseSQLAlchemyObjectType):
         info,
         from_time=None,
         until_time=None,
-        only_non_validated_missions=False,
+        only_ended_missions=False,
         first=None,
         after=None,
     ):
@@ -179,7 +179,7 @@ class CompanyOutput(BaseSQLAlchemyObjectType):
             end_time=until_time,
             first=first,
             after=after,
-            only_non_validated_missions=only_non_validated_missions,
+            only_ended_missions=only_ended_missions,
         )
 
     @with_authorization_policy(

--- a/app/models/mission.py
+++ b/app/models/mission.py
@@ -181,3 +181,10 @@ class Mission(EventBaseModel):
 
     def ended_for(self, user):
         return len([e for e in self.ends if e.user_id == user.id]) > 0
+
+    def ended_for_all_users(self):
+        users = list(set([a.user for a in self.acknowledged_activities]))
+        for u in users:
+            if not self.ended_for(u):
+                return False
+        return True

--- a/app/models/queries.py
+++ b/app/models/queries.py
@@ -162,6 +162,7 @@ def query_company_missions(
                 ),
                 isouter=True,
             )
+            .filter(~Activity.is_dismissed)
             .group_by(Mission.id)
             .having(func.every(MissionEnd.id.isnot(None)))
         )


### PR DESCRIPTION
Suppression du paramètre only_non_validated_missions et rajout de only_ended_missions pour visualiser les missions validées par un gestionnaire.
https://trello.com/c/TrgPS0ix/371-visualiser-les-missions-d%C3%A9j%C3%A0-valid%C3%A9es

Je n'ai pas réussi à faire la requête avec SQLAlchemy, du coup j'ai fait le filtre des missions terminées en python.
La requête est la suivante : 

````sql
select distinct m.id from mission m
where not exists(
        select a.mission_id
        from activity a
            left join mission_end me on a.mission_id = me.mission_id and me.user_id = a.user_id
        where a.dismissed_at is null
          and me.mission_id is null
          and m.id = a.mission_id
    )
;
````