### PR TITLE
Add endpoints to change mission name and update location entries

### DIFF
--- a/app/controllers/__init__.py
+++ b/app/controllers/__init__.py
@@ -32,6 +32,7 @@ from app.controllers.mission import (
     ValidateMission,
     Query as MissionQuery,
     UpdateMissionVehicle,
+    ChangeMissionName,
 )
 from app.controllers.user import (
     UserSignUp,
@@ -76,6 +77,7 @@ class Activities(graphene.ObjectType):
     edit_activity = EditActivity.Field()
     log_location = LogMissionLocation.Field()
     update_mission_vehicle = UpdateMissionVehicle.Field()
+    change_mission_name = ChangeMissionName.Field()
     register_kilometer_at_location = RegisterKilometerAtLocation.Field()
 
 


### PR DESCRIPTION
PR pour la refonte du drawer mission (https://trello.com/c/0Qm6ajkm/365-visualiser-le-d%C3%A9tail-dune-mission-%C3%A0-valider), qui ajoute :

* un endpoint pour modifier le nom du mission par un company admin

* la possibilité pour un company admin de modifier un lieu de début/fin de mission