### PR TITLE
Allow former employee to access vehicles and known addresses on compa…

### DIFF
--- a/app/data_access/company.py
+++ b/app/data_access/company.py
@@ -5,6 +5,7 @@ from app.data_access.mission import MissionConnection
 from app.domain.permissions import (
     company_admin,
     is_employed_by_company_over_period,
+    has_any_employment_with_company,
 )
 from app.domain.work_days import WorkDayStatsOnly
 from app.helpers.authorization import with_authorization_policy, current_user
@@ -135,7 +136,7 @@ class CompanyOutput(BaseSQLAlchemyObjectType):
         return self.query_current_users()
 
     @with_authorization_policy(
-        is_employed_by_company_over_period,
+        has_any_employment_with_company,
         get_target_from_args=lambda self, info: self,
         error_message="Forbidden access to field 'vehicles' of company object.",
     )
@@ -260,7 +261,7 @@ class CompanyOutput(BaseSQLAlchemyObjectType):
         )
 
     @with_authorization_policy(
-        is_employed_by_company_over_period,
+        has_any_employment_with_company,
         get_target_from_args=lambda self, info: self,
         error_message="Forbidden access to field 'knownAddresses' of company object.",
     )

--- a/app/domain/permissions.py
+++ b/app/domain/permissions.py
@@ -67,6 +67,20 @@ def is_employed_by_company_over_period(
     return True
 
 
+def has_any_employment_with_company(actor, company_obj_or_id):
+    company_id = company_obj_or_id
+    if type(company_obj_or_id) is Company:
+        company_id = company_obj_or_id.id
+
+    return any(
+        [
+            e.company_id == company_id
+            for e in actor.employments
+            if e.is_not_rejected and not e.is_dismissed
+        ]
+    )
+
+
 def self_or_have_common_company(actor, user_obj_or_id):
     user = user_obj_or_id
     if type(user_obj_or_id) is int:


### PR DESCRIPTION
…ny object.

Changement au système de permissions : 

* un utilisateur rattaché à une entreprise peut accéder aux véhicules et aux adresses connues de l'entreprise (`vehicles` et `knownAddresses`), même si son rattachement est dans le passé ou dans le futur.