### PR TITLE
Add explicit error message when trying to record an activity in the future

### DIFF
--- a/app/helpers/errors.py
+++ b/app/helpers/errors.py
@@ -142,6 +142,27 @@ class EmptyActivityDurationError(MobilicError):
     )
 
 
+class ActivityInFutureError(MobilicError):
+    code = "ACTIVITY_TIME_IN_FUTURE"
+
+    def __init__(
+        self,
+        event_time,
+        reception_time,
+        event_name,
+        message="You can not record activity in the future.",
+        **kwargs,
+    ):
+        super().__init__(message, **kwargs)
+        self.extensions.update(
+            dict(
+                eventTime=to_timestamp(event_time),
+                receptionTime=to_timestamp(reception_time),
+                eventName=event_name,
+            )
+        )
+
+
 class OverlappingActivitiesError(MobilicError):
     code = "OVERLAPPING_ACTIVITIES"
     default_should_alert_team = False


### PR DESCRIPTION
https://trello.com/c/qaYdRBQe/571-message-derreur-dans-le-cas-dun-enregistrement-dactivit%C3%A9-dans-le-futur

Message d'erreur spécifique si un utilisateur tente de renseigner une activité dans le futur.

PR du front : https://github.com/MTES-MCT/mobilic/pull/114