### PR TITLE
Add user_id in employment property for email

### DIFF
--- a/app/controllers/employment.py
+++ b/app/controllers/employment.py
@@ -114,6 +114,8 @@ class CreateEmployment(AuthenticatedMutation):
                     .filter(func.lower(User.email) == func.lower(user_email))
                     .one_or_none()
                 )
+            if user:
+                user_id = user.id
 
             start_date = employment_input.get("start_date", date.today())
 


### PR DESCRIPTION
Sending the right email when creating an invitation : if the user exists, we should put a redeem invite link

https://trello.com/c/E4ifs3x8/584-invitation-en-double-apr%C3%A8s-acceptation-dans-le-mail