### PR TITLE
Add geolocation information in dismissable warning

### DIFF
--- a/app/controllers/user.py
+++ b/app/controllers/user.py
@@ -602,10 +602,12 @@ def generate_mission_export(mission_id, user_id):
 class WarningToDisableType(str, Enum):
     EMPLOYEE_VALIDATION = "employee-validation"
     ADMIN_MISSION_MODIFICATION = "admin-mission-modification"
+    EMPLOYEE_GEOLOCATION_INFORMATION = "employee-geolocation-information"
     __description__ = """
 Enumération des valeurs suivantes.
 - "employee-validation" : alerte relative au caractère bloquant de la validation par le salarié
 - "admin-mission-modification" : alerte relative à la visibilité des modifications de la mission par un gestionnaire 
+- "employee-geolocation-information" : Modale d'information sur la géolocalisation 
 """
 
 


### PR DESCRIPTION
https://trello.com/c/rm9Vmrc4/525-etq-salari%C3%A9-revoir-la-mani%C3%A8re-dautoriser-le-partage-de-la-position-actuelle

Add an entry in dismissable warnings to avoid showing geolocation modal multiple times

PR for front : https://github.com/MTES-MCT/mobilic/pull/142