### PR TITLE
Add specific errors when terminating an employment

### DIFF
--- a/app/controllers/employment.py
+++ b/app/controllers/employment.py
@@ -21,6 +21,8 @@ from app.helpers.errors import (
     InvalidTokenError,
     InvalidResourceError,
     UserSelfChangeRoleError,
+    ActivityExistAfterEmploymentEndDate,
+    EmploymentAlreadyTerminated,
 )
 from app.helpers.mail import MailjetError
 from app.helpers.authorization import (
@@ -378,7 +380,7 @@ class TerminateEmployment(AuthenticatedMutation):
             employment = Employment.query.get(employment_id)
 
             if not employment.is_acknowledged or employment.end_date:
-                raise InvalidResourceError(
+                raise EmploymentAlreadyTerminated(
                     f"Employment is inactive or has already an end date"
                 )
 
@@ -395,7 +397,7 @@ class TerminateEmployment(AuthenticatedMutation):
                 ).count()
                 > 0
             ):
-                raise InvalidParamsError(
+                raise ActivityExistAfterEmploymentEndDate(
                     "User has logged activities for the company after this end date"
                 )
 

--- a/app/helpers/errors.py
+++ b/app/helpers/errors.py
@@ -252,6 +252,14 @@ class InvalidResourceError(MobilicError):
     code = "INVALID_RESOURCE"
 
 
+class EmploymentAlreadyTerminated(MobilicError):
+    code = "EMPLOYMENT_ALREADY_TERMINATED"
+
+
+class ActivityExistAfterEmploymentEndDate(MobilicError):
+    code = "ACTIVITY_EXIST_AFTER_EMPLOYMENT_END_DATE"
+
+
 class ResourceAlreadyDismissedError(InvalidResourceError):
     pass
 


### PR DESCRIPTION
https://trello.com/c/T48Pkk5G/669-modifier-le-message-derreur-en-cas-de-non-succ%C3%A8s-du-d%C3%A9tachement-dun-salari%C3%A9

Message spécifique lorsqu'on veut terminer un rattachement dans le cas où :

- Le rattachement est déjà terminé
- Il existe des activités postérieures à la date de fin demandée

PR FRONT : https://github.com/MTES-MCT/mobilic/pull/172 
