### PR TITLE
feat: error on activity creation before employment

### DIFF
--- a/app/domain/permissions.py
+++ b/app/domain/permissions.py
@@ -6,6 +6,8 @@ from flask import g
 
 from app.helpers.authorization import active
 from app.helpers.errors import (
+    ActivityBeforeEmploymentByAdminError,
+    ActivityBeforeEmploymentByEmployeeError,
     AuthorizationError,
     MissionAlreadyValidatedByAdminError,
     MissionAlreadyValidatedByUserError,
@@ -149,7 +151,10 @@ def check_actor_can_write_on_mission_over_period(
         end=end,
         include_pending_invite=False,
     ):
-        _raise_authorization_error()
+        if for_user == actor:
+            raise ActivityBeforeEmploymentByEmployeeError()
+        else:
+            raise ActivityBeforeEmploymentByAdminError()
 
     is_actor_company_admin = company_admin(actor, mission.company_id)
     # 4. Check that actor can log for the eventual user (must be either a company admin, the user himself or the team leader)

--- a/app/domain/permissions.py
+++ b/app/domain/permissions.py
@@ -6,8 +6,8 @@ from flask import g
 
 from app.helpers.authorization import active
 from app.helpers.errors import (
-    ActivityBeforeEmploymentByAdminError,
-    ActivityBeforeEmploymentByEmployeeError,
+    ActivityOutsideEmploymentByAdminError,
+    ActivityOutsideEmploymentByEmployeeError,
     AuthorizationError,
     MissionAlreadyValidatedByAdminError,
     MissionAlreadyValidatedByUserError,
@@ -152,9 +152,9 @@ def check_actor_can_write_on_mission_over_period(
         include_pending_invite=False,
     ):
         if for_user == actor:
-            raise ActivityBeforeEmploymentByEmployeeError()
+            raise ActivityOutsideEmploymentByEmployeeError()
         else:
-            raise ActivityBeforeEmploymentByAdminError()
+            raise ActivityOutsideEmploymentByAdminError()
 
     is_actor_company_admin = company_admin(actor, mission.company_id)
     # 4. Check that actor can log for the eventual user (must be either a company admin, the user himself or the team leader)

--- a/app/helpers/errors.py
+++ b/app/helpers/errors.py
@@ -146,14 +146,14 @@ class EmptyActivityDurationError(MobilicError):
     )
 
 
-class ActivityBeforeEmploymentByEmployeeError(MobilicError):
-    code = "ACTIVITY_BEFORE_EMPLOYMENT_EMPLOYEE"
-    default_message = "Activity can't be added before employment"
+class ActivityOutsideEmploymentByEmployeeError(MobilicError):
+    code = "ACTIVITY_OUTSIDE_EMPLOYMENT_EMPLOYEE"
+    default_message = "Activity can't be added outside employment period"
 
 
-class ActivityBeforeEmploymentByAdminError(MobilicError):
-    code = "ACTIVITY_BEFORE_EMPLOYMENT_ADMIN"
-    default_message = "Activity can't be added before employment"
+class ActivityOutsideEmploymentByAdminError(MobilicError):
+    code = "ACTIVITY_OUTSIDE_EMPLOYMENT_ADMIN"
+    default_message = "Activity can't be added outside employment period"
 
 
 class ActivityInFutureError(MobilicError):

--- a/app/helpers/errors.py
+++ b/app/helpers/errors.py
@@ -146,6 +146,16 @@ class EmptyActivityDurationError(MobilicError):
     )
 
 
+class ActivityBeforeEmploymentByEmployeeError(MobilicError):
+    code = "ACTIVITY_BEFORE_EMPLOYMENT_EMPLOYEE"
+    default_message = "Activity can't be added before employment"
+
+
+class ActivityBeforeEmploymentByAdminError(MobilicError):
+    code = "ACTIVITY_BEFORE_EMPLOYMENT_ADMIN"
+    default_message = "Activity can't be added before employment"
+
+
 class ActivityInFutureError(MobilicError):
     code = "ACTIVITY_TIME_IN_FUTURE"
 


### PR DESCRIPTION
https://trello.com/c/SljAfxUK/749-modifier-le-message-derreur-lorsque-lon-renseigne-une-date-ant%C3%A9rieure-au-rattachement-du-salari%C3%A9

PR front: https://github.com/MTES-MCT/mobilic/pull/214