### PR TITLE
Fix signature problem that prevented to export xls for admins.

### DIFF
--- a/app/helpers/xls/controllers/__init__.py
+++ b/app/helpers/xls/controllers/__init__.py
@@ -1,4 +1,8 @@
-from app.helpers.xls.common import ExcelWriter, send_excel_file
+from io import BytesIO
+
+from xlsxwriter import Workbook
+
+from app.helpers.xls.common import send_excel_file
 from app.helpers.xls.controllers.tab_details_single_control import (
     write_details_sheet,
 )
@@ -10,17 +14,16 @@ from app.helpers.xls.controllers.tab_main_single_control import (
 def send_control_as_one_excel_file(
     control, work_days_data, min_date, max_date
 ):
-    with ExcelWriter(add_signature=False) as (wb, output):
-        wdays_with_activities = list(
-            filter(lambda wd: len(wd.activities) > 0, work_days_data)
-        )
-        write_main_sheet(
-            wb, control, wdays_with_activities, min_date, max_date
-        )
-        write_details_sheet(
-            wb, control, wdays_with_activities, min_date, max_date
-        )
+    output = BytesIO()
+    wb = Workbook(output)
 
+    wdays_with_activities = list(
+        filter(lambda wd: len(wd.activities) > 0, work_days_data)
+    )
+    write_main_sheet(wb, control, wdays_with_activities, min_date, max_date)
+    write_details_sheet(wb, control, wdays_with_activities, min_date, max_date)
+    wb.close()
+    output.seek(0)
     return send_excel_file(
         file=output, name=f"Contrôle_Mobilic_#{control.id}.xlsx"
     )


### PR DESCRIPTION
la méthode __exit__ de la classe ExcelWriter ne changeait pas la valeur de sortie de output.
==> Les fichiers n'étaient plus signés
==> Les stream de BytesIo n'étaient pas seek à 0, ce qui empêche le fichier d'être envoyé.