### PR TITLE
fix: update last_update_time when freezing activity

### DIFF
--- a/app/models/activity.py
+++ b/app/models/activity.py
@@ -115,7 +115,11 @@ class Activity(UserEventBaseModel, Dismissable, Period):
             if frozen_version.end_time:
                 self.end_time = frozen_version.end_time
             else:
+                # 1mn added to comply with "activity_start_time_before_end_time" constraint
                 self.end_time = at_time + timedelta(minutes=1)
+                # last_update_time updated to comply with "activity_end_time_before_update_time" constraint
+                self.last_update_time = at_time
+                # these changes will not be commited see app/controllers/controller.py
             return self
         else:
             return None

--- a/app/models/activity.py
+++ b/app/models/activity.py
@@ -116,9 +116,10 @@ class Activity(UserEventBaseModel, Dismissable, Period):
                 self.end_time = frozen_version.end_time
             else:
                 # 1mn added to comply with "activity_start_time_before_end_time" constraint
-                self.end_time = at_time + timedelta(minutes=1)
                 # last_update_time updated to comply with "activity_end_time_before_update_time" constraint
-                self.last_update_time = at_time
+                self.last_update_time = self.end_time = at_time + timedelta(
+                    minutes=1
+                )
                 # these changes will not be commited see app/controllers/controller.py
             return self
         else:


### PR DESCRIPTION
https://trello.com/c/8qWInZfP/834-bug-lors-dun-contr%C3%B4le-juste-apr%C3%A8s-avoir-d%C3%A9marr%C3%A9-une-activit%C3%A9