### PR TITLE
Consider a dismissed activity as ended when dismissed when querying activities

### DIFF
--- a/app/models/queries.py
+++ b/app/models/queries.py
@@ -75,9 +75,11 @@ def _apply_time_range_filters_to_activity_query(query, start_time, end_time):
     end_time = to_datetime(end_time, date_as_end_of_day=True)
     if start_time or end_time:
         return query.filter(
-            func.tsrange(Activity.start_time, Activity.end_time, "[]").op(
-                "&&"
-            )(
+            func.tsrange(
+                Activity.start_time,
+                func.coalesce(Activity.end_time, Activity.dismissed_at),
+                "[]",
+            ).op("&&")(
                 DateTimeRange(
                     to_tz(start_time, timezone.utc) if start_time else None,
                     to_tz(end_time, timezone.utc) if end_time else None,


### PR DESCRIPTION
https://trello.com/c/MhMapiHX/852-etq-contr%C3%B4leur-jai-acc%C3%A8s-%C3%A0-une-mission-salari%C3%A9-contr%C3%B4l%C3%A9-ant%C3%A9rieure-aux-28-jours-journ%C3%A9e-en-cours

Si on avait une activité en cours par exemple le 01/11 à 10h, et qu'on la dismissed à 10h30, lorsqu'on sélectionnait les activités avec une date range postérieure au 01/11 à 10h30, l'activité était tout de même remontée.

Je considère maintenant que son heure de fin est à 10h30 pour que le calcul avec les date range puisse se faire.