### PR TITLE
Feat/change history wording

### DIFF
--- a/app/domain/history.py
+++ b/app/domain/history.py
@@ -89,22 +89,22 @@ class LogAction(NamedTuple):
         if type(self.resource) is Activity:
             if self.type == LogActionType.CREATE:
                 if self.version.end_time:
-                    return f"a ajouté l'activité {format_activity_type(self.resource.type)} de {format_time(self.version.start_time, show_dates)} à {format_time(self.version.end_time, show_dates)}"
-                return f"s'est mis en {format_activity_type(self.resource.type)} à {format_time(self.version.start_time, show_dates)}"
+                    return f"a ajouté l'activité {format_activity_type(self.resource.type)} du {format_time(self.version.start_time, True)} au {format_time(self.version.end_time, True)}"
+                return f"s'est mis en {format_activity_type(self.resource.type)} le {format_time(self.version.start_time, True)}"
 
             if self.type == LogActionType.DELETE:
                 if self.resource.end_time:
-                    return f"a supprimé l'activité {format_activity_type(self.resource.type)} de {format_time(self.resource.start_time, show_dates)} à {format_time(self.resource.end_time, show_dates)}"
-                return f"a supprimé l'activité {format_activity_type(self.resource.type)} démarrée à {format_time(self.resource.start_time, show_dates)}"
+                    return f"a supprimé l'activité {format_activity_type(self.resource.type)} du {format_time(self.resource.start_time, True)} au {format_time(self.resource.end_time, True)}"
+                return f"a supprimé l'activité {format_activity_type(self.resource.type)} démarrée le {format_time(self.resource.start_time, True)}"
 
             previous_version = self.version.previous_version
             if not self.version.end_time and not previous_version.end_time:
-                return f"a décalé l'heure de début de l'activité {format_activity_type(self.resource.type)} de {format_time(previous_version.start_time, show_dates)} à {format_time(self.version.start_time, show_dates)}"
+                return f"a décalé le début de l'activité {format_activity_type(self.resource.type)} du {format_time(previous_version.start_time, True)} au {format_time(self.version.start_time, True)}"
             if not self.version.end_time and previous_version.end_time:
                 return f"a repris l'activité {format_activity_type(self.resource.type)}"
             if self.version.end_time and not previous_version.end_time:
-                return f"a mis fin à l'activité {format_activity_type(self.resource.type)} à {format_time(self.version.end_time, show_dates)}"
-            return f"a modifié la période de l'activité {format_activity_type(self.resource.type)} de {format_time(previous_version.start_time, show_dates)} - {format_time(previous_version.end_time, show_dates)} à {format_time(self.version.start_time, show_dates)} - {format_time(self.version.end_time, show_dates)}"
+                return f"a mis fin à l'activité {format_activity_type(self.resource.type)} le {format_time(self.version.end_time, True)}"
+            return f"a modifié la période de l'activité {format_activity_type(self.resource.type)} de {format_time(previous_version.start_time, True)} - {format_time(previous_version.end_time, True)} à {format_time(self.version.start_time, True)} - {format_time(self.version.end_time, True)}"
 
 
 def actions_history(

--- a/app/domain/history.py
+++ b/app/domain/history.py
@@ -75,7 +75,7 @@ class LogAction(NamedTuple):
                 return Picto.ACTIVITY_TRANSFER
         return Picto.MODIFICATION
 
-    def text(self, show_dates):
+    def text(self):
         if self.is_validation:
             return "a validé la mission"
 

--- a/app/domain/history.py
+++ b/app/domain/history.py
@@ -81,7 +81,7 @@ class LogAction(NamedTuple):
 
         if type(self.resource) is LocationEntry:
             # Only creations
-            return f"a renseigné le lieu de {'début' if self.resource.type == LocationEntryType.MISSION_START_LOCATION else 'fin'} de service : {self.resource.address.format()}"
+            return f"a indiqué comme lieu de {'début' if self.resource.type == LocationEntryType.MISSION_START_LOCATION else 'fin'} de service : {self.resource.address.format()}"
 
         if type(self.resource) is Expenditure:
             return f"a {'ajouté' if self.type == LogActionType.CREATE else 'supprimé'} le frais {format_expenditure_label(self.resource.type)}"

--- a/app/helpers/xls/columns.py
+++ b/app/helpers/xls/columns.py
@@ -312,7 +312,7 @@ COLUMN_EVENT_AUTHOR_STATUS = ExcelColumn(
 )
 COLUMN_EVENT_DESC = ExcelColumn(
     "Description de l'enregistrement",
-    lambda event: event.text(False),
+    lambda event: event.text(),
     lambda _: None,
     60,
     light_green_hex,

--- a/app/templates/filters.py
+++ b/app/templates/filters.py
@@ -30,7 +30,7 @@ MONTHS = [
 
 def format_time(value, show_dates):
     if show_dates:
-        return to_fr_tz(value).strftime("%d/%m/%y %H:%M")
+        return to_fr_tz(value).strftime(f"%d/%m à %H:%M")
     return to_fr_tz(value).strftime("%H:%M")
 
 
@@ -63,14 +63,14 @@ def format_activity_type(activity_or_break_type):
     from app.models.activity import ActivityType
 
     if activity_or_break_type == ActivityType.WORK:
-        return "autre tâche"
+        return "Autre tâche"
     if activity_or_break_type == ActivityType.DRIVE:
-        return "conduite"
+        return "Déplacement"
     if activity_or_break_type == ActivityType.SUPPORT:
-        return "accompagnement"
+        return "Accompagnement"
     if activity_or_break_type == ActivityType.TRANSFER:
-        return "liaison"
-    return "pause"
+        return "Liaison"
+    return "Pause"
 
 
 def format_expenditure_label(expenditure_type):

--- a/app/templates/mission_details_pdf.html
+++ b/app/templates/mission_details_pdf.html
@@ -425,7 +425,7 @@
         </tr>
         <tr>
             <td class="comment-content">
-                {{ action.text(show_dates) }}
+                {{ action.text() }}
             </td>
         </tr>
         {% endfor %}


### PR DESCRIPTION
https://trello.com/c/OYwxpeAz/803-probl%C3%A8me-de-tournure-des-phrases-dans-lhistorique-de-saisie

Ne plus différencier les missions sur plusieurs jours / sur un seul jour. ==> Simplification des règles pour l'affichage de l'historique de saisie d'une mission.