### PR TITLE
Fix/create inner mission

### DIFF
--- a/app/domain/log_activities.py
+++ b/app/domain/log_activities.py
@@ -59,7 +59,7 @@ def _check_inter_mission_overlaps(user, mission):
     for activity in other_mission_activities_in_potential_conflict:
         if not (
             (activity.end_time and activity.end_time <= mission_start)
-            or (activity.start_time >= mission_end)
+            or (mission_end and activity.start_time >= mission_end)
         ):
             raise OverlappingMissionsError(
                 f"Mission cannot overlap with mission {activity.mission_id} for the user.",

--- a/app/models/user.py
+++ b/app/models/user.py
@@ -174,7 +174,7 @@ class User(BaseModel, RandomNineIntId, WithEmploymentHistory):
                 ~Activity.is_dismissed,
                 Activity.start_time < date_time,
                 or_(
-                    Activity.end_time.is_(None), Activity.end_time < date_time
+                    Activity.end_time.is_(None), Activity.end_time <= date_time
                 ),
             )
             .order_by(desc(Activity.start_time))

--- a/app/tests/test_activity_overlaps.py
+++ b/app/tests/test_activity_overlaps.py
@@ -159,6 +159,13 @@ class TestActivityOverlaps(BaseTest):
             datetime(2021, 1, 1, 13, 30),
             should_raise=OverlappingMissionsError,
         )
+
+        self.create_mission_with_work_activity(
+            datetime(2021, 1, 1, 12),
+            datetime(2021, 1, 1, 12, 30),
+            should_raise=OverlappingMissionsError,
+        )
+
         self.create_mission_with_work_activity(
             datetime(2021, 1, 1, 17),
             datetime(2021, 1, 1, 19),


### PR DESCRIPTION
https://trello.com/c/T3bXj2VJ/868-erreur-checkintermissionoverlaps-pendant-appel-activitieslogactivity

Deux corrections dans cette PR : 
- on vérifie que la mission à comparer pour overlap à une date de fin, pour éviter des exceptions
- Correction de la fonction qui empêche de créer une mission dans une autre : on pouvait créer des missions dans une autre mission en faisant commencer une deuxième mission au début d'une pause d'une mission existante.

PR FRONT : https://github.com/MTES-MCT/mobilic/pull/269