### PR TITLE
Restrict admin activity creation / modification / deletion without mission validation

### DIFF
--- a/app/controllers/activity.py
+++ b/app/controllers/activity.py
@@ -1,21 +1,27 @@
-import graphene
 from datetime import datetime
+
+import graphene
 from graphene.types.generic import GenericScalar
 from sqlalchemy.orm import selectinload
 
 from app import db
 from app.controllers.utils import atomic_transaction, Void
-from app.domain.permissions import check_actor_can_write_on_mission_over_period
-from app.helpers.authentication import current_user, AuthenticatedMutation
+from app.data_access.activity import ActivityOutput
 from app.domain.log_activities import log_activity
+from app.domain.permissions import (
+    check_actor_can_write_on_mission_over_period,
+    check_actor_can_edit_activity,
+    check_actor_can_log_without_mission_validation,
+)
+from app.helpers.authentication import current_user, AuthenticatedMutation
+from app.helpers.authorization import (
+    with_authorization_policy,
+    active,
+)
 from app.helpers.errors import (
     AuthorizationError,
     ResourceAlreadyDismissedError,
     InvalidParamsError,
-)
-from app.helpers.authorization import (
-    with_authorization_policy,
-    active,
 )
 from app.helpers.graphene_types import (
     graphene_enum_type,
@@ -23,7 +29,6 @@ from app.helpers.graphene_types import (
 )
 from app.models import User, Mission
 from app.models.activity import Activity, ActivityType
-from app.data_access.activity import ActivityOutput
 
 
 class ActivityLogInput:
@@ -111,6 +116,16 @@ class LogActivity(AuthenticatedMutation):
 
     @classmethod
     @with_authorization_policy(active)
+    @with_authorization_policy(
+        check_actor_can_log_without_mission_validation,
+        get_target_from_args=lambda *args, **kwargs: {
+            "mission": Mission.query.options(
+                selectinload(Mission.activities)
+            ).get(kwargs["mission_id"]),
+            "user": User.query.get(kwargs["user_id"]),
+        },
+        error_message="Actor is not authorized to log in the mission",
+    )
     def mutate(cls, _, info, **activity_input):
         with atomic_transaction(commit_at_end=True):
             return log_activity_(input=activity_input)
@@ -253,6 +268,13 @@ class CancelActivity(AuthenticatedMutation):
 
     @classmethod
     @with_authorization_policy(active)
+    @with_authorization_policy(
+        check_actor_can_edit_activity,
+        get_target_from_args=lambda *args, **kwargs: Activity.query.get(
+            kwargs["activity_id"]
+        ),
+        error_message="Actor is not authorized to edit the activity",
+    )
     def mutate(cls, _, info, **edit_input):
         with atomic_transaction(commit_at_end=True):
             edit_activity(
@@ -277,6 +299,13 @@ class EditActivity(AuthenticatedMutation):
 
     @classmethod
     @with_authorization_policy(active)
+    @with_authorization_policy(
+        check_actor_can_edit_activity,
+        get_target_from_args=lambda *args, **kwargs: Activity.query.get(
+            kwargs["activity_id"]
+        ),
+        error_message="Actor is not authorized to edit the activity",
+    )
     def mutate(cls, _, info, **edit_input):
         with atomic_transaction(commit_at_end=True):
             if (

--- a/app/domain/permissions.py
+++ b/app/domain/permissions.py
@@ -205,6 +205,22 @@ def check_actor_can_write_on_mission_for_user(actor, mission_user_tuple):
     )
 
 
+def check_actor_can_edit_activity(actor, activity):
+    return activity and (
+        actor.id == activity.submitter_id or actor.id == activity.user_id
+    )
+
+
+def check_actor_can_log_without_mission_validation(actor, mission_user_tuple):
+    mission = mission_user_tuple.get("mission")
+    user = mission_user_tuple.get("user")
+    return (
+        mission
+        and user
+        and (actor.id == mission.submitter_id or actor.id == user.id)
+    )
+
+
 def check_actor_can_write_on_mission(actor, mission, for_user=None, at=None):
     return check_actor_can_write_on_mission_over_period(
         actor, mission, for_user, start=at, end=at

--- a/app/tests/test_permission_activities.py
+++ b/app/tests/test_permission_activities.py
@@ -1,0 +1,220 @@
+from datetime import datetime
+
+from app import app, db
+from app.domain.log_activities import log_activity
+from app.helpers.errors import AuthorizationError
+from app.models import Mission
+from app.models.activity import ActivityType, Activity
+from app.seed import UserFactory, CompanyFactory
+from app.tests import (
+    BaseTest,
+    AuthenticatedUserContext,
+)
+from app.tests.helpers import make_authenticated_request, ApiRequests
+
+
+class TestPermissionActivities(BaseTest):
+    def setUp(self):
+        super().setUp()
+        self.company = CompanyFactory.create()
+        self.admin = UserFactory.create(
+            post__company=self.company, post__has_admin_rights=True
+        )
+        self.another_admin = UserFactory.create(
+            post__company=self.company, post__has_admin_rights=True
+        )
+        self.worker = UserFactory.create(post__company=self.company)
+        with app.app_context():
+            with AuthenticatedUserContext(user=self.worker):
+                self.mission_by_worker = Mission.create(
+                    submitter=self.worker,
+                    company=self.company,
+                    reception_time=datetime.now(),
+                )
+                self.activity_by_worker = log_activity(
+                    submitter=self.worker,
+                    user=self.worker,
+                    mission=self.mission_by_worker,
+                    type=ActivityType.WORK,
+                    switch_mode=True,
+                    reception_time=datetime.now(),
+                    start_time=datetime(2022, 1, 1, 1),
+                    end_time=datetime(2022, 1, 1, 2),
+                )
+            db.session.commit()
+
+            with AuthenticatedUserContext(user=self.admin):
+                self.mission_by_admin = Mission.create(
+                    submitter=self.admin,
+                    company=self.company,
+                    reception_time=datetime.now(),
+                )
+                self.activity_by_admin = log_activity(
+                    submitter=self.admin,
+                    user=self.worker,
+                    mission=self.mission_by_admin,
+                    type=ActivityType.WORK,
+                    switch_mode=True,
+                    reception_time=datetime.now(),
+                    start_time=datetime(2022, 2, 1, 1),
+                    end_time=datetime(2022, 2, 1, 2),
+                )
+
+                log_activity(
+                    submitter=self.admin,
+                    user=self.worker,
+                    mission=self.mission_by_worker,
+                    type=ActivityType.WORK,
+                    switch_mode=True,
+                    reception_time=datetime.now(),
+                    start_time=datetime(2022, 1, 2, 1),
+                    end_time=datetime(2022, 1, 2, 2),
+                )
+            db.session.flush()
+            db.session.commit()
+
+    def tearDown(self):
+        super().tearDown()
+
+    def test_worker_can_dismiss_its_activity(self):
+        response = make_authenticated_request(
+            time=datetime.now(),
+            submitter_id=self.worker.id,
+            query=ApiRequests.cancel_activity,
+            variables=dict(
+                activity_id=self.activity_by_worker.id,
+            ),
+        )
+        self.assertTrue(
+            response["data"]["activities"]["cancelActivity"]["success"]
+        )
+        self.assertEqual(
+            self.worker.id,
+            Activity.query.get(self.activity_by_worker.id).dismiss_author.id,
+        )
+
+    def test_worker_can_edit_its_activity(self):
+        response = make_authenticated_request(
+            time=datetime.now(),
+            submitter_id=self.worker.id,
+            query=ApiRequests.edit_activity,
+            variables=dict(
+                activity_id=self.activity_by_worker.id,
+                end_time=datetime(2022, 1, 1, 3),
+            ),
+        )
+        self.assertEqual(
+            self.activity_by_worker.id,
+            response["data"]["activities"]["editActivity"]["id"],
+        )
+        self.assertTrue(
+            datetime(2022, 1, 1, 3),
+            Activity.query.get(self.activity_by_worker.id).end_time,
+        )
+
+    def test_admin_cannot_dismiss_worker_activity(self):
+        response = make_authenticated_request(
+            time=datetime.now(),
+            submitter_id=self.admin.id,
+            query=ApiRequests.cancel_activity,
+            variables=dict(
+                activity_id=self.activity_by_worker.id,
+            ),
+        )
+        self.assertEqual(
+            AuthorizationError.code,
+            response["errors"][0]["extensions"]["code"],
+        )
+        self.assertIsNone(
+            Activity.query.get(self.activity_by_worker.id).dismiss_author
+        )
+
+    def test_admin_cannot_edit_worker_activity(self):
+        response = make_authenticated_request(
+            time=datetime.now(),
+            submitter_id=self.admin.id,
+            query=ApiRequests.edit_activity,
+            variables=dict(
+                activity_id=self.activity_by_worker.id,
+                end_time=datetime(2022, 1, 1, 3),
+            ),
+        )
+        self.assertEqual(
+            AuthorizationError.code,
+            response["errors"][0]["extensions"]["code"],
+        )
+        self.assertTrue(
+            datetime(2022, 1, 1, 2),
+            Activity.query.get(self.activity_by_worker.id).end_time,
+        )
+
+    def test_admin_can_dismiss_an_activity_he_created(self):
+        response = make_authenticated_request(
+            time=datetime.now(),
+            submitter_id=self.admin.id,
+            query=ApiRequests.cancel_activity,
+            variables=dict(
+                activity_id=self.activity_by_admin.id,
+            ),
+        )
+        self.assertTrue(
+            response["data"]["activities"]["cancelActivity"]["success"]
+        )
+        self.assertEqual(
+            self.admin.id,
+            Activity.query.get(self.activity_by_admin.id).dismiss_author.id,
+        )
+
+    def test_admin_can_edit_an_activity_he_created(self):
+        response = make_authenticated_request(
+            time=datetime.now(),
+            submitter_id=self.admin.id,
+            query=ApiRequests.edit_activity,
+            variables=dict(
+                activity_id=self.activity_by_admin.id,
+                end_time=datetime(2022, 2, 1, 3),
+            ),
+        )
+        self.assertEqual(
+            self.activity_by_admin.id,
+            response["data"]["activities"]["editActivity"]["id"],
+        )
+        self.assertTrue(
+            datetime(2022, 2, 1, 3),
+            Activity.query.get(self.activity_by_admin.id).end_time,
+        )
+
+    def test_admin_can_log_in_a_mission_he_created(self):
+        response = make_authenticated_request(
+            time=datetime.now(),
+            submitter_id=self.admin.id,
+            query=ApiRequests.log_activity,
+            variables=dict(
+                type=ActivityType.DRIVE,
+                start_time=datetime(2022, 2, 2, 1),
+                mission_id=self.mission_by_admin.id,
+                user_id=self.worker.id,
+            ),
+        )
+        self.assertIsNotNone(
+            response["data"]["activities"]["logActivity"]["id"]
+        )
+
+    def test_admin_cannot_log_in_a_mission_he_did_not_created(self):
+        response = make_authenticated_request(
+            time=datetime.now(),
+            submitter_id=self.admin.id,
+            query=ApiRequests.log_activity,
+            variables=dict(
+                type=ActivityType.DRIVE,
+                start_time=datetime(2022, 1, 3, 1),
+                end_time=datetime(2022, 1, 3, 2),
+                switch=False,
+                mission_id=self.mission_by_worker.id,
+                user_id=self.worker.id,
+            ),
+        )
+        self.assertEqual(
+            AuthorizationError.code,
+            response["errors"][0]["extensions"]["code"],
+        )


### PR DESCRIPTION
https://trello.com/c/b3fEIKL7/696-restreindre-la-modification-dactivit%C3%A9-de-mission-par-un-gestionnaire