### PR TITLE
fix: do not duplicate address if already exists

### DIFF
--- a/app/controllers/location_entry.py
+++ b/app/controllers/location_entry.py
@@ -83,15 +83,16 @@ class CreateCompanyKnownAddress(AuthenticatedMutation):
             raise InvalidParamsError(
                 "Exactly one of geoApiData or manualAddress should be set"
             )
-        company_known_address = CompanyKnownAddress(
-            alias=alias,
-            address=Address.get_or_create(
-                geo_api_data=geo_api_data, manual_address=manual_address
-            ),
-            company_id=company_id,
-        )
-        db.session.add(company_known_address)
-        db.session.commit()
+
+        with atomic_transaction(commit_at_end=True):
+            company_known_address = CompanyKnownAddress(
+                alias=alias,
+                address=Address.get_or_create(
+                    geo_api_data=geo_api_data, manual_address=manual_address
+                ),
+                company_id=company_id,
+            )
+            db.session.add(company_known_address)
         return company_known_address
 
 

--- a/app/helpers/errors.py
+++ b/app/helpers/errors.py
@@ -316,6 +316,12 @@ class MissionLocationAlreadySetError(MobilicError):
     default_should_alert_team = False
 
 
+class CompanyAddressAlreadyRegisteredError(MobilicError):
+    code = "COMPANY_ADDRESS_ALREADY_REGISTERED"
+    default_message = "The address already exists"
+    default_should_alert_team = False
+
+
 CONFLICTING_ROW_ID_RE = re.compile(r", (\d+)\)\.$")
 
 
@@ -381,6 +387,7 @@ CONSTRAINTS_TO_ERRORS_MAP = {
         mission_end=_get_conflicting_mission_end(error)
     ),
     "unique_registration_numbers_among_company": lambda _: VehicleAlreadyRegisteredError(),
+    "only_one_entry_per_company_and_address": lambda _: CompanyAddressAlreadyRegisteredError(),
 }
 
 

--- a/app/models/address.py
+++ b/app/models/address.py
@@ -1,3 +1,4 @@
+from decimal import Decimal
 from sqlalchemy.dialects.postgresql import JSONB
 import graphene
 
@@ -50,7 +51,17 @@ class Address(BaseModel):
         for addr in existing_addresses:
             are_addresses_equal = True
             for key, value in properties.items():
-                if value != getattr(addr, key):
+                if key == "coords":
+                    # example:
+                    # value = [2.412745, 47.107928]
+                    # existing_coords = [Decimal('2.412745'), Decimal('47.107928')]
+                    existing_coords = getattr(addr, key)
+                    if not existing_coords[0].compare(
+                        Decimal(value[0])
+                    ) or not existing_coords[1].compare(Decimal(value[1])):
+                        are_addresses_equal = False
+                        break
+                elif value != getattr(addr, key):
                     are_addresses_equal = False
                     break
             if are_addresses_equal:

--- a/app/tests/helpers.py
+++ b/app/tests/helpers.py
@@ -74,6 +74,29 @@ class ApiRequests:
             }
         }
     """
+    log_location = """
+        mutation logLocation(
+            $type: LocationEntryTypeEnum!
+            $missionId: Int!
+            $geoApiData: GenericScalar
+            $manualAddress: String
+        ) {
+            activities {
+                logLocation(
+                    missionId: $missionId
+                    type: $type
+                    geoApiData: $geoApiData
+                    manualAddress: $manualAddress
+                ) {
+                    id
+                    name
+                    alias
+                    postalCode
+                    city
+                }
+            }
+        }
+    """
     create_mission = """
         mutation ($name: String, $companyId: Int!, $context: GenericScalar, $vehicleId: Int) {
             activities {

--- a/app/tests/test_log_location.py
+++ b/app/tests/test_log_location.py
@@ -1,0 +1,103 @@
+from datetime import datetime
+
+from app.models.activity import ActivityType
+from app.models.address import Address
+from app.seed import UserFactory
+from app.seed.factories import CompanyFactory
+from app.tests import BaseTest
+from app.tests.helpers import ApiRequests, make_authenticated_request
+
+
+class TestLogLocation(BaseTest):
+    def setUp(self):
+        super().setUp()
+        self.company = CompanyFactory.create()
+        self.employee = UserFactory.create(
+            first_name="Employ", last_name="Yi", post__company=self.company
+        )
+
+    def begin_mission(self, time):
+        create_mission_response = make_authenticated_request(
+            time=time,
+            submitter_id=self.employee.id,
+            query=ApiRequests.create_mission,
+            variables={"company_id": self.company.id},
+        )
+        mission_id = create_mission_response["data"]["activities"][
+            "createMission"
+        ]["id"]
+        make_authenticated_request(
+            time=time,
+            submitter_id=self.employee.id,
+            query=ApiRequests.log_activity,
+            variables=dict(
+                start_time=time,
+                mission_id=mission_id,
+                type=ActivityType.WORK,
+                user_id=self.employee.id,
+                switch=True,
+            ),
+        )
+        return mission_id
+
+    def test_log_location_should_not_create_twice_same_address(self):
+        mission_id = self.begin_mission(datetime(2020, 2, 7, 6))
+        geo_api_data = {
+            "type": "Feature",
+            "geometry": {
+                "type": "Point",
+                "coordinates": [2.412745, 47.107928],
+            },
+            "properties": {
+                "label": "Avenue du Général de Gaulle 18000 Bourges",
+                "score": 0.8891745454545453,
+                "id": "18033_2461",
+                "name": "Avenue du Général de Gaulle",
+                "postcode": "18000",
+                "citycode": "18033",
+                "x": 655466.12,
+                "y": 6667684.16,
+                "city": "Bourges",
+                "context": "18, Cher, Centre-Val de Loire",
+                "type": "street",
+                "importance": 0.78092,
+            },
+        }
+
+        make_authenticated_request(
+            time=datetime(2020, 2, 7, 7),
+            submitter_id=self.employee.id,
+            query=ApiRequests.log_location,
+            variables=dict(
+                mission_id=mission_id,
+                type="mission_start_location",
+                geoApiData=geo_api_data,
+            ),
+        )
+        self.assertEqual(
+            Address.query.filter(
+                Address.name == "Avenue du Général de Gaulle",
+                Address.postal_code == "18000",
+                Address.city == "Bourges",
+            ).count(),
+            1,
+        )
+
+        make_authenticated_request(
+            time=datetime(2020, 2, 7, 7),
+            submitter_id=self.employee.id,
+            query=ApiRequests.log_location,
+            variables=dict(
+                mission_id=mission_id,
+                type="mission_end_location",
+                geoApiData=geo_api_data,
+            ),
+        )
+        self.assertEqual(
+            Address.query.filter(
+                Address.name == "Avenue du Général de Gaulle",
+                Address.postal_code == "18000",
+                Address.city == "Bourges",
+            ).count(),
+            1,
+        )

--- a/migrations/versions/52434978c99e_fix_duplicate_addresses.py
+++ b/migrations/versions/52434978c99e_fix_duplicate_addresses.py
@@ -19,68 +19,68 @@ depends_on = None
 def upgrade():
     op.execute(
         """
-      alter table address 
-      add column new_address_id int4;
+        ALTER TABLE address 
+        ADD COLUMN new_address_id int4;
 
-      update address a set new_address_id = r.new_address_id
-      from (
-        select geo_api_id, min(id) as new_address_id from address 
-        where geo_api_id is not null 
-        group by geo_api_id 
-        having count(*) > 1
-      ) as r 
-      where a.geo_api_id is not null 
-      and a.geo_api_id = r.geo_api_id
-      and a.id <> r.new_address_id;
+        UPDATE address a SET new_address_id = r.new_address_id
+        FROM (
+          SELECT geo_api_id, min(id) AS new_address_id FROM address 
+          WHERE geo_api_id IS NOT NULL 
+          GROUP BY geo_api_id 
+          HAVING COUNT(*) > 1
+        ) AS r 
+        WHERE a.geo_api_id IS NOT NULL 
+        AND a.geo_api_id = r.geo_api_id
+        AND a.id <> r.new_address_id;
 
-      alter table company_known_address
-      add column new_address_id int4,
-      add column new_company_known_address_id int4;
+        ALTER TABLE company_known_address
+        ADD COLUMN new_address_id int4,
+        ADD COLUMN new_company_known_address_id int4;
 
-      update company_known_address set new_address_id = a.new_address_id
-      from address a 
-      where a.id = address_id and a.new_address_id is not null;
+        UPDATE company_known_address SET new_address_id = a.new_address_id
+        FROM address a 
+        WHERE a.id = address_id AND a.new_address_id IS NOT NULL;
 
-      update company_known_address set new_address_id = address_id 
-      where new_address_id is null;
+        UPDATE company_known_address SET new_address_id = address_id 
+        WHERE new_address_id IS NULL;
 
-      update company_known_address cka set new_company_known_address_id = r.new_company_known_address_id
-      from (
-      select company_id, new_address_id, max(id) as new_company_known_address_id from company_known_address 
-      group by company_id, new_address_id 
-      having count(*) > 1
-      ) as r 
-      where cka.new_address_id = r.new_address_id
-      and cka.company_id = r.company_id
-      and r.new_company_known_address_id <> cka.id;
+        UPDATE company_known_address cka SET new_company_known_address_id = r.new_company_known_address_id
+        FROM (
+        SELECT company_id, new_address_id, max(id) AS new_company_known_address_id FROM company_known_address 
+        GROUP BY company_id, new_address_id 
+        HAVING COUNT(*) > 1
+        ) AS r 
+        WHERE cka.new_address_id = r.new_address_id
+        AND cka.company_id = r.company_id
+        AND r.new_company_known_address_id <> cka.id;
 
-      update location_entry set address_id = a.new_address_id
-      from address a 
-      where a.id = address_id 
-      and a.new_address_id is not null;
+        UPDATE location_entry SET address_id = a.new_address_id
+        FROM address a 
+        WHERE a.id = address_id 
+        AND a.new_address_id IS NOT NULL;
 
-      update location_entry set company_known_address_id  = cka.new_company_known_address_id
-      from company_known_address cka 
-      where cka.id = company_known_address_id 
-      and cka.new_company_known_address_id is not null 
-      and cka.new_company_known_address_id <> company_known_address_id;
+        UPDATE location_entry SET company_known_address_id  = cka.new_company_known_address_id
+        FROM company_known_address cka 
+        WHERE cka.id = company_known_address_id 
+        AND cka.new_company_known_address_id IS NOT NULL 
+        AND cka.new_company_known_address_id <> company_known_address_id;
 
-      delete from company_known_address 
-      where new_company_known_address_id is not null;
+        DELETE FROM company_known_address 
+        WHERE new_company_known_address_id IS NOT NULL;
 
-      update company_known_address set address_id = new_address_id 
-      where new_address_id <> address_id;
+        UPDATE company_known_address SET address_id = new_address_id 
+        WHERE new_address_id <> address_id;
 
-      delete from address 
-      where new_address_id is not null;
+        DELETE FROM address 
+        WHERE new_address_id IS NOT NULL;
 
-      alter table address 
-      drop column new_address_id;
+        ALTER TABLE address 
+        DROP COLUMN new_address_id;
 
-      alter table company_known_address
-      drop column new_address_id,
-      drop column new_company_known_address_id;
-      """
+        ALTER TABLE company_known_address
+        DROP COLUMN new_address_id,
+        DROP COLUMN new_company_known_address_id;
+        """
     )
 
 

--- a/migrations/versions/52434978c99e_fix_duplicate_addresses.py
+++ b/migrations/versions/52434978c99e_fix_duplicate_addresses.py
@@ -24,7 +24,7 @@ def upgrade():
 
         UPDATE address a SET new_address_id = r.new_address_id
         FROM (
-          SELECT geo_api_id, min(id) AS new_address_id FROM address 
+          SELECT geo_api_id, max(id) AS new_address_id FROM address 
           WHERE geo_api_id IS NOT NULL 
           GROUP BY geo_api_id 
           HAVING COUNT(*) > 1
@@ -80,6 +80,9 @@ def upgrade():
         ALTER TABLE company_known_address
         DROP COLUMN new_address_id,
         DROP COLUMN new_company_known_address_id;
+
+        REINDEX TABLE address;
+        REINDEX TABLE company_known_address;
         """
     )
 

--- a/migrations/versions/52434978c99e_fix_duplicate_addresses.py
+++ b/migrations/versions/52434978c99e_fix_duplicate_addresses.py
@@ -1,0 +1,89 @@
+"""fix duplicate addresses
+
+Revision ID: 52434978c99e
+Revises: 660b542c1ed2
+Create Date: 2022-12-06 10:28:35.437685
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = "52434978c99e"
+down_revision = "660b542c1ed2"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.execute(
+        """
+      alter table address 
+      add column new_address_id int4;
+
+      update address a set new_address_id = r.new_address_id
+      from (
+        select geo_api_id, min(id) as new_address_id from address 
+        where geo_api_id is not null 
+        group by geo_api_id 
+        having count(*) > 1
+      ) as r 
+      where a.geo_api_id is not null 
+      and a.geo_api_id = r.geo_api_id
+      and a.id <> r.new_address_id;
+
+      alter table company_known_address
+      add column new_address_id int4,
+      add column new_company_known_address_id int4;
+
+      update company_known_address set new_address_id = a.new_address_id
+      from address a 
+      where a.id = address_id and a.new_address_id is not null;
+
+      update company_known_address set new_address_id = address_id 
+      where new_address_id is null;
+
+      update company_known_address cka set new_company_known_address_id = r.new_company_known_address_id
+      from (
+      select company_id, new_address_id, max(id) as new_company_known_address_id from company_known_address 
+      group by company_id, new_address_id 
+      having count(*) > 1
+      ) as r 
+      where cka.new_address_id = r.new_address_id
+      and cka.company_id = r.company_id
+      and r.new_company_known_address_id <> cka.id;
+
+      update location_entry set address_id = a.new_address_id
+      from address a 
+      where a.id = address_id 
+      and a.new_address_id is not null;
+
+      update location_entry set company_known_address_id  = cka.new_company_known_address_id
+      from company_known_address cka 
+      where cka.id = company_known_address_id 
+      and cka.new_company_known_address_id is not null 
+      and cka.new_company_known_address_id <> company_known_address_id;
+
+      delete from company_known_address 
+      where new_company_known_address_id is not null;
+
+      update company_known_address set address_id = new_address_id 
+      where new_address_id <> address_id;
+
+      delete from address 
+      where new_address_id is not null;
+
+      alter table address 
+      drop column new_address_id;
+
+      alter table company_known_address
+      drop column new_address_id,
+      drop column new_company_known_address_id;
+      """
+    )
+
+
+def downgrade():
+    # nothing to do
+    pass


### PR DESCRIPTION
Explication : 
Si au moins un attribut de l'adresse déjà existante est différent, une nouvelle entrée est créée.
Les doublons apparaissaient car la comparaison des coordonnées de l'adresse était incorrect : on comparait un tableau de float avec un tableau de Decimal => ça renvoyait toujours qu'ils sont différents.

Réalisé : 
- Correction du code introduisant les doublons
- Script de migration pour supprimer les doublons en base

Ticket trello : https://trello.com/c/OGQryuFo/872-suppression-doublon-dans-table-address
PR front : https://github.com/MTES-MCT/mobilic/pull/277