### PR TITLE
EmailAlreadyRegisteredError sends a less explicit message

### DIFF
--- a/app/helpers/errors.py
+++ b/app/helpers/errors.py
@@ -123,8 +123,8 @@ class TokenExpiredError(MobilicError):
 
 
 class EmailAlreadyRegisteredError(MobilicError):
-    code = "EMAIL_ALREADY_REGISTERED"
-    default_message = "A user is already registered for this email"
+    code = "ERROR_WHILE_REGISTERING_USER"
+    default_message = "An error occurred while registering user"
     default_should_alert_team = False
 
 


### PR DESCRIPTION
https://trello.com/c/zPacrdHW/939-supprimer-message-sp%C3%A9cifique-si-on-veut-cr%C3%A9er-un-compte-avec-un-utilisateur-existant
I didn't change the class name because that's informative for us. I just made the code and message less specific