### PR TITLE
Feat/regulatory additional info

### DIFF
--- a/app/domain/regulations_per_day.py
+++ b/app/domain/regulations_per_day.py
@@ -177,10 +177,10 @@ def check_max_work_day_time(activity_groups, regulation_check):
         worked_time_in_seconds = group.total_work_duration
         extra = dict(
             night_work=night_work,
-            max_time_in_hours=max_time_in_hours,
-            worked_time_in_seconds=worked_time_in_seconds,
-            worked_period_start=group.start_time.isoformat(),
-            worked_period_end=group.end_time.isoformat(),
+            max_work_range_in_hours=max_time_in_hours,
+            work_range_in_seconds=worked_time_in_seconds,
+            work_range_start=group.start_time.isoformat(),
+            work_range_end=group.end_time.isoformat(),
         )
         if worked_time_in_seconds > max_time_in_hours * HOUR:
             return ComputationResult(success=False, extra=extra)

--- a/app/domain/regulations_per_day.py
+++ b/app/domain/regulations_per_day.py
@@ -223,25 +223,33 @@ def check_min_work_day_break(activity_groups, regulation_check):
             latest_work_time = activity.end_time
 
     if total_work_duration_s > MINIMUM_DURATION_WORK_IN_HOURS_1 * HOUR:
+        extra = dict(
+            total_break_time_in_seconds=total_break_time_s,
+            work_range_in_seconds=total_work_duration_s,
+            work_range_start=activity_groups[0].start_time.isoformat(),
+            work_range_end=latest_work_time.isoformat(),
+        )
         if (
             total_work_duration_s <= MINIMUM_DURATION_WORK_IN_HOURS_2 * HOUR
             and total_break_time_s < MINIMUM_DURATION_BREAK_IN_MIN_1 * MINUTE
         ):
+            extra[
+                "min_break_time_in_minutes"
+            ] = MINIMUM_DURATION_BREAK_IN_MIN_1
             return ComputationResult(
                 success=False,
-                extra=dict(
-                    min_time_in_minutes=MINIMUM_DURATION_BREAK_IN_MIN_1
-                ),
+                extra=extra,
             )
         elif (
             total_work_duration_s > MINIMUM_DURATION_WORK_IN_HOURS_2 * HOUR
             and total_break_time_s < MINIMUM_DURATION_BREAK_IN_MIN_2 * MINUTE
         ):
+            extra[
+                "min_break_time_in_minutes"
+            ] = MINIMUM_DURATION_BREAK_IN_MIN_2
             return ComputationResult(
                 success=False,
-                extra=dict(
-                    min_time_in_minutes=MINIMUM_DURATION_BREAK_IN_MIN_2
-                ),
+                extra=extra,
             )
 
     return ComputationResult(success=True)

--- a/app/domain/regulations_per_day.py
+++ b/app/domain/regulations_per_day.py
@@ -260,8 +260,10 @@ def check_min_work_day_break(activity_groups, regulation_check):
             total_break_time_in_seconds=total_break_time_s,
             work_range_in_seconds=total_work_duration_s,
             work_range_start=activity_groups[0].start_time.isoformat(),
-            work_range_end=latest_work_time.isoformat(),
         )
+        if latest_work_time is not None:
+            extra["work_range_end"] = latest_work_time.isoformat()
+
         if (
             total_work_duration_s <= MINIMUM_DURATION_WORK_IN_HOURS_2 * HOUR
             and total_break_time_s < MINIMUM_DURATION_BREAK_IN_MIN_1 * MINUTE

--- a/app/domain/regulations_per_day.py
+++ b/app/domain/regulations_per_day.py
@@ -174,10 +174,15 @@ def check_max_work_day_time(activity_groups, regulation_check):
             if night_work
             else MAXIMUM_DURATION_OF_DAY_WORK_IN_HOURS
         )
+        worked_time_in_seconds = group.total_work_duration
         extra = dict(
-            night_work=night_work, max_time_in_hours=max_time_in_hours
+            night_work=night_work,
+            max_time_in_hours=max_time_in_hours,
+            worked_time_in_seconds=worked_time_in_seconds,
+            worked_period_start=group.start_time.isoformat(),
+            worked_period_end=group.end_time.isoformat(),
         )
-        if group.total_work_duration > max_time_in_hours * HOUR:
+        if worked_time_in_seconds > max_time_in_hours * HOUR:
             return ComputationResult(success=False, extra=extra)
 
     return ComputationResult(success=True, extra=extra)

--- a/app/domain/regulations_per_week.py
+++ b/app/domain/regulations_per_week.py
@@ -42,26 +42,23 @@ def check_max_worked_day_in_week(week, regulation_check):
     MAXIMUM_DAY_WORKED_BY_WEEK = regulation_check.variables[
         "MAXIMUM_DAY_WORKED_BY_WEEK"
     ]
-    if week["worked_days"] > MAXIMUM_DAY_WORKED_BY_WEEK:
-        return ComputationResult(
-            success=False,
-            extra=dict(
-                too_many_days=True, rest_duration_s=week["rest_duration_s"]
-            ),
-        )
-
     MINIMUM_WEEKLY_BREAK_IN_HOURS = regulation_check.variables[
         "MINIMUM_WEEKLY_BREAK_IN_HOURS"
     ]
-    if week["rest_duration_s"] < MINIMUM_WEEKLY_BREAK_IN_HOURS * HOUR:
-        return ComputationResult(
-            success=False,
-            extra=dict(
-                too_many_days=False, rest_duration_s=week["rest_duration_s"]
-            ),
-        )
+    extra = dict(
+        max_nb_days_worked_by_week=MAXIMUM_DAY_WORKED_BY_WEEK,
+        min_weekly_break_in_hours=MINIMUM_WEEKLY_BREAK_IN_HOURS,
+    )
+    too_many_days = week["worked_days"] > MAXIMUM_DAY_WORKED_BY_WEEK
+    not_enough_rest = (
+        week["rest_duration_s"] < MINIMUM_WEEKLY_BREAK_IN_HOURS * HOUR
+    )
+    extra["too_many_days"] = too_many_days
+    if not_enough_rest:
+        extra["rest_duration_s"] = week["rest_duration_s"]
 
-    return ComputationResult(success=True)
+    success = not (too_many_days or not_enough_rest)
+    return ComputationResult(success=success, extra=extra)
 
 
 WEEKLY_REGULATION_CHECKS = {

--- a/app/domain/regulations_per_week.py
+++ b/app/domain/regulations_per_week.py
@@ -7,6 +7,8 @@ from app.models.regulation_check import RegulationCheck, RegulationCheckType
 from app.models.regulatory_alert import RegulatoryAlert
 from sqlalchemy import desc
 
+SANCTION_CODE_WEEKLY_WORK = "NATINF 13152"
+
 
 def compute_regulations_per_week(user, week, submitter_type):
 
@@ -56,6 +58,7 @@ def check_max_worked_day_in_week(week, regulation_check):
     extra["too_many_days"] = too_many_days
     if not_enough_rest:
         extra["rest_duration_s"] = week["rest_duration_s"]
+        extra["sanction_code"] = SANCTION_CODE_WEEKLY_WORK
 
     success = not (too_many_days or not_enough_rest)
     return ComputationResult(success=success, extra=extra)

--- a/app/domain/regulations_per_week.py
+++ b/app/domain/regulations_per_week.py
@@ -7,7 +7,7 @@ from app.models.regulation_check import RegulationCheck, RegulationCheckType
 from app.models.regulatory_alert import RegulatoryAlert
 from sqlalchemy import desc
 
-SANCTION_CODE_WEEKLY_WORK = "NATINF 13152"
+NATINF_13152 = "NATINF 13152"
 
 
 def compute_regulations_per_week(user, week, submitter_type):
@@ -58,7 +58,7 @@ def check_max_worked_day_in_week(week, regulation_check):
     extra["too_many_days"] = too_many_days
     if not_enough_rest:
         extra["rest_duration_s"] = week["rest_duration_s"]
-        extra["sanction_code"] = SANCTION_CODE_WEEKLY_WORK
+        extra["sanction_code"] = NATINF_13152
 
     success = not (too_many_days or not_enough_rest)
     return ComputationResult(success=success, extra=extra)

--- a/app/tests/test_regulations.py
+++ b/app/tests/test_regulations.py
@@ -6,6 +6,7 @@ from app import app, db
 from app.domain import regulations
 from app.domain.log_activities import log_activity
 from app.domain.validation import validate_mission
+from app.helpers.regulations_utils import HOUR
 from app.helpers.submitter_type import SubmitterType
 from app.models import Mission
 from app.models.activity import ActivityType
@@ -509,9 +510,9 @@ class TestRegulations(BaseTest):
                 mission=mission,
                 type=ActivityType.DRIVE,
                 switch_mode=False,
-                reception_time=get_time(how_many_days_ago, hour=15),
-                start_time=get_time(how_many_days_ago, hour=7),
-                end_time=get_time(how_many_days_ago, hour=15),
+                reception_time=get_time(how_many_days_ago, hour=16),
+                start_time=get_time(how_many_days_ago, hour=8),
+                end_time=get_time(how_many_days_ago, hour=16),
             )
 
             validate_mission(
@@ -533,6 +534,15 @@ class TestRegulations(BaseTest):
         extra_info = json.loads(regulatory_alert.extra)
         self.assertEqual(extra_info["night_work"], True)
         self.assertIsNotNone(extra_info["max_time_in_hours"])
+        self.assertEqual(extra_info["worked_time_in_seconds"], 11 * HOUR)
+        self.assertEqual(
+            datetime.fromisoformat(extra_info["worked_period_start"]),
+            get_time(how_many_days_ago, hour=4),
+        )
+        self.assertEqual(
+            datetime.fromisoformat(extra_info["worked_period_end"]),
+            get_time(how_many_days_ago, hour=16),
+        )
 
     def test_max_work_day_time_by_admin_failure(self):
         company = self.company
@@ -594,6 +604,15 @@ class TestRegulations(BaseTest):
         extra_info = json.loads(regulatory_alert.extra)
         self.assertEqual(extra_info["night_work"], True)
         self.assertIsNotNone(extra_info["max_time_in_hours"])
+        self.assertEqual(extra_info["worked_time_in_seconds"], 13 * HOUR)
+        self.assertEqual(
+            datetime.fromisoformat(extra_info["worked_period_start"]),
+            get_time(how_many_days_ago, hour=4),
+        )
+        self.assertEqual(
+            datetime.fromisoformat(extra_info["worked_period_end"]),
+            get_time(how_many_days_ago, hour=17),
+        )
 
     def test_min_work_day_break_by_employee_success(self):
         company = self.company

--- a/app/tests/test_regulations.py
+++ b/app/tests/test_regulations.py
@@ -5,7 +5,7 @@ from unittest.mock import patch
 from app import app, db
 from app.domain import regulations
 from app.domain.log_activities import log_activity
-from app.domain.regulations_per_week import SANCTION_CODE_WEEKLY_WORK
+from app.domain.regulations_per_week import NATINF_13152
 from app.domain.validation import validate_mission
 from app.helpers.regulations_utils import HOUR, MINUTE
 from app.helpers.submitter_type import SubmitterType
@@ -1092,9 +1092,7 @@ class TestRegulations(BaseTest):
         self.assertTrue(extra_info["too_many_days"])
         self.assertIn("rest_duration_s", extra_info)
         self.assertEqual(extra_info["rest_duration_s"], 14 * HOUR)
-        self.assertEqual(
-            extra_info["sanction_code"], SANCTION_CODE_WEEKLY_WORK
-        )
+        self.assertEqual(extra_info["sanction_code"], NATINF_13152)
 
     def test_compute_regulations_per_week_not_enough_break(self):
         company = self.company
@@ -1184,9 +1182,7 @@ class TestRegulations(BaseTest):
         extra_info = json.loads(regulatory_alert.extra)
         self.assertFalse(extra_info["too_many_days"])
         self.assertEqual(extra_info["rest_duration_s"], 111600)
-        self.assertEqual(
-            extra_info["sanction_code"], SANCTION_CODE_WEEKLY_WORK
-        )
+        self.assertEqual(extra_info["sanction_code"], NATINF_13152)
 
     def test_max_work_day_time_in_guyana_success(self):
         company = self.company

--- a/app/tests/test_regulations.py
+++ b/app/tests/test_regulations.py
@@ -6,7 +6,7 @@ from app import app, db
 from app.domain import regulations
 from app.domain.log_activities import log_activity
 from app.domain.validation import validate_mission
-from app.helpers.regulations_utils import HOUR
+from app.helpers.regulations_utils import HOUR, MINUTE
 from app.helpers.submitter_type import SubmitterType
 from app.models import Mission
 from app.models.activity import ActivityType
@@ -720,7 +720,21 @@ class TestRegulations(BaseTest):
         ).one_or_none()
         self.assertIsNotNone(regulatory_alert)
         extra_info = json.loads(regulatory_alert.extra)
-        self.assertEqual(extra_info["min_time_in_minutes"], 45)
+        self.assertEqual(extra_info["min_break_time_in_minutes"], 45)
+        self.assertEqual(
+            extra_info["total_break_time_in_seconds"], 30 * MINUTE
+        )
+        self.assertEqual(
+            extra_info["work_range_in_seconds"], 9 * HOUR + 30 * MINUTE
+        )
+        self.assertEqual(
+            datetime.fromisoformat(extra_info["work_range_start"]),
+            get_time(how_many_days_ago, hour=16),
+        )
+        self.assertEqual(
+            datetime.fromisoformat(extra_info["work_range_end"]),
+            get_time(how_many_days_ago - 1, hour=2),
+        )
 
     def test_max_uninterrupted_work_time_by_employee_success(self):
         company = self.company

--- a/app/tests/test_regulations.py
+++ b/app/tests/test_regulations.py
@@ -841,6 +841,24 @@ class TestRegulations(BaseTest):
             RegulatoryAlert.submitter_type == SubmitterType.EMPLOYEE,
         ).one_or_none()
         self.assertIsNotNone(regulatory_alert)
+        extra_info = json.loads(regulatory_alert.extra)
+        self.assertEqual(extra_info["max_uninterrupted_work_in_hours"], 6)
+        self.assertEqual(
+            extra_info["longest_uninterrupted_work_in_seconds"],
+            6 * HOUR + 15 * MINUTE,
+        )
+        self.assertEqual(
+            datetime.fromisoformat(
+                extra_info["longest_uninterrupted_work_start"]
+            ),
+            get_time(how_many_days_ago, hour=17),
+        )
+        self.assertEqual(
+            datetime.fromisoformat(
+                extra_info["longest_uninterrupted_work_end"]
+            ),
+            get_time(how_many_days_ago, hour=23, minute=15),
+        )
 
     def test_use_latest_regulation_check_by_type(self):
         company = self.company

--- a/app/tests/test_regulations.py
+++ b/app/tests/test_regulations.py
@@ -533,14 +533,14 @@ class TestRegulations(BaseTest):
         self.assertIsNotNone(regulatory_alert)
         extra_info = json.loads(regulatory_alert.extra)
         self.assertEqual(extra_info["night_work"], True)
-        self.assertIsNotNone(extra_info["max_time_in_hours"])
-        self.assertEqual(extra_info["worked_time_in_seconds"], 11 * HOUR)
+        self.assertIsNotNone(extra_info["max_work_range_in_hours"])
+        self.assertEqual(extra_info["work_range_in_seconds"], 11 * HOUR)
         self.assertEqual(
-            datetime.fromisoformat(extra_info["worked_period_start"]),
+            datetime.fromisoformat(extra_info["work_range_start"]),
             get_time(how_many_days_ago, hour=4),
         )
         self.assertEqual(
-            datetime.fromisoformat(extra_info["worked_period_end"]),
+            datetime.fromisoformat(extra_info["work_range_end"]),
             get_time(how_many_days_ago, hour=16),
         )
 
@@ -603,14 +603,14 @@ class TestRegulations(BaseTest):
         self.assertIsNotNone(regulatory_alert)
         extra_info = json.loads(regulatory_alert.extra)
         self.assertEqual(extra_info["night_work"], True)
-        self.assertIsNotNone(extra_info["max_time_in_hours"])
-        self.assertEqual(extra_info["worked_time_in_seconds"], 13 * HOUR)
+        self.assertIsNotNone(extra_info["max_work_range_in_hours"])
+        self.assertEqual(extra_info["work_range_in_seconds"], 13 * HOUR)
         self.assertEqual(
-            datetime.fromisoformat(extra_info["worked_period_start"]),
+            datetime.fromisoformat(extra_info["work_range_start"]),
             get_time(how_many_days_ago, hour=4),
         )
         self.assertEqual(
-            datetime.fromisoformat(extra_info["worked_period_end"]),
+            datetime.fromisoformat(extra_info["work_range_end"]),
             get_time(how_many_days_ago, hour=17),
         )
 

--- a/app/tests/test_regulations.py
+++ b/app/tests/test_regulations.py
@@ -310,8 +310,22 @@ class TestRegulations(BaseTest):
                 RegulationCheck.type == RegulationCheckType.MINIMUM_DAILY_REST
             ),
             RegulatoryAlert.submitter_type == SubmitterType.EMPLOYEE,
-        ).all()
-        self.assertEqual(len(regulatory_alert), 1)
+        ).one_or_none()
+        self.assertIsNotNone(regulatory_alert)
+        extra_info = json.loads(regulatory_alert.extra)
+        self.assertEqual(extra_info["min_daily_break_in_hours"], 10)
+        self.assertEqual(
+            datetime.fromisoformat(extra_info["breach_period_start"]),
+            get_time(how_many_days_ago, hour=18),
+        )
+        self.assertEqual(
+            datetime.fromisoformat(extra_info["breach_period_end"]),
+            get_time(how_many_days_ago - 1, hour=18),
+        )
+        self.assertEqual(
+            extra_info["breach_period_max_break_in_seconds"],
+            10 * HOUR - 1 * MINUTE,
+        )
 
     def test_min_daily_rest_by_employee_failure_only_one_day(self):
         company = self.company
@@ -370,8 +384,20 @@ class TestRegulations(BaseTest):
                 RegulationCheck.type == RegulationCheckType.MINIMUM_DAILY_REST
             ),
             RegulatoryAlert.submitter_type == SubmitterType.EMPLOYEE,
-        ).all()
-        self.assertEqual(1, len(regulatory_alert))
+        ).one_or_none()
+        self.assertIsNotNone(regulatory_alert)
+        extra_info = json.loads(regulatory_alert.extra)
+        self.assertEqual(
+            datetime.fromisoformat(extra_info["breach_period_start"]),
+            get_time(how_many_days_ago - 1, hour=6),
+        )
+        self.assertEqual(
+            datetime.fromisoformat(extra_info["breach_period_end"]),
+            get_time(how_many_days_ago - 2, hour=6),
+        )
+        self.assertEqual(
+            extra_info["breach_period_max_break_in_seconds"], 9 * HOUR
+        )
 
     def test_min_daily_rest_by_employee_failure(self):
         company = self.company
@@ -425,6 +451,18 @@ class TestRegulations(BaseTest):
             RegulatoryAlert.submitter_type == SubmitterType.EMPLOYEE,
         ).one_or_none()
         self.assertIsNotNone(regulatory_alert)
+        extra_info = json.loads(regulatory_alert.extra)
+        self.assertEqual(
+            datetime.fromisoformat(extra_info["breach_period_start"]),
+            get_time(how_many_days_ago, hour=13),
+        )
+        self.assertEqual(
+            datetime.fromisoformat(extra_info["breach_period_end"]),
+            get_time(how_many_days_ago - 1, hour=13),
+        )
+        self.assertEqual(
+            extra_info["breach_period_max_break_in_seconds"], 8 * HOUR
+        )
 
     def test_max_work_day_time_by_employee_success(self):
         company = self.company

--- a/app/tests/test_regulations.py
+++ b/app/tests/test_regulations.py
@@ -5,6 +5,7 @@ from unittest.mock import patch
 from app import app, db
 from app.domain import regulations
 from app.domain.log_activities import log_activity
+from app.domain.regulations_per_week import SANCTION_CODE_WEEKLY_WORK
 from app.domain.validation import validate_mission
 from app.helpers.regulations_utils import HOUR, MINUTE
 from app.helpers.submitter_type import SubmitterType
@@ -1091,6 +1092,9 @@ class TestRegulations(BaseTest):
         self.assertTrue(extra_info["too_many_days"])
         self.assertIn("rest_duration_s", extra_info)
         self.assertEqual(extra_info["rest_duration_s"], 14 * HOUR)
+        self.assertEqual(
+            extra_info["sanction_code"], SANCTION_CODE_WEEKLY_WORK
+        )
 
     def test_compute_regulations_per_week_not_enough_break(self):
         company = self.company
@@ -1180,6 +1184,9 @@ class TestRegulations(BaseTest):
         extra_info = json.loads(regulatory_alert.extra)
         self.assertFalse(extra_info["too_many_days"])
         self.assertEqual(extra_info["rest_duration_s"], 111600)
+        self.assertEqual(
+            extra_info["sanction_code"], SANCTION_CODE_WEEKLY_WORK
+        )
 
     def test_max_work_day_time_in_guyana_success(self):
         company = self.company


### PR DESCRIPTION
https://trello.com/c/FIHUUCmx/929-enregistrer-les-dur%C3%A9es-et-p%C3%A9riodes-pour-les-d%C3%A9passements-de-seuils

Objectif du ticket: Etre capable d'afficher les informations suivantes pour les différentes règles
- **non-respect(s) du repos quotidien**
Le Mercredi 2 Novembre 2022 à 12h50
Durée du repos le plus long sur les dernières 24h: 8h30 (1h30m de moins que les 10h règlementaires)

- **dépassement(s) de la durée maximale du travail quotidien**
Entre le Mercredi 2 Novembre 2022 à 4h00 et le Mercredi 2 Novembre à 18h00, 11h de travail ont été constatées (dépassement d'1h de la limite de [10h en cas de travail de nuit | de 12h])

- **non-respect(s) du temps de pause**
Entre le Mercredi 2 Novembre 2022 à 4h00 et le Mercredi 2 Novembre à 18h00, 38 minutes de pause ont été constatées (7 minutes de moins que les 45 minutes règlementaires dans le cas d'un temps de travail de 9h23)

- **dépassement(s) de la durée maximale du travail ininterrompu**
Un travail ininterrompu de 7h23m a été constaté entre le Mercredi 2 Novembre à 10h00 et le Mercredi 2 Novembre à 17h23 (1h23m de plus que la règlementation de 6h)

- **non-respect(s) du repos hebdomadaire**
Semaine du Lundi 3 Septembre 2022 au Dimanche 9 Septembre 2022: 7 jours travaillés (contre 6 règlementaires)
ET / OU (important de savoir les 2 distinctement)
Semaine du Lundi 3 Septembre 2022 au Dimanche 9 Septembre 2022: plus grande pause de 32h (2h de moins que les 34h règlementaires)
NB: à priori compliqué d'indiquer de quand à quand va la plus grande pause




