### PR TITLE
Feat/team employees tab

### DIFF
--- a/app/controllers/__init__.py
+++ b/app/controllers/__init__.py
@@ -29,6 +29,7 @@ from app.controllers.controller import Query as ControllerUserQuery
 from app.controllers.employment import (
     CancelEmployment,
     ChangeEmployeeRole,
+    ChangeEmployeeTeam,
     CreateEmployment,
     CreateWorkerEmploymentsFromEmails,
     GetInvitation,
@@ -158,6 +159,7 @@ class Employments(graphene.ObjectType):
     send_invitation_reminder = SendInvitationReminder.Field()
     batch_create_worker_employments = CreateWorkerEmploymentsFromEmails.Field()
     change_employee_role = ChangeEmployeeRole.Field()
+    change_employee_team = ChangeEmployeeTeam.Field()
 
 
 class Vehicles(graphene.ObjectType):

--- a/app/controllers/employment.py
+++ b/app/controllers/employment.py
@@ -13,6 +13,7 @@ from app.data_access.company import CompanyOutput
 from app.data_access.employment import EmploymentOutput
 from app.domain.employment import create_employment_by_third_party_if_needed
 from app.domain.permissions import company_admin
+from app.domain.team import remove_admin_from_teams
 from app.domain.third_party_employment import (
     create_third_party_employment_link_if_needed,
 )
@@ -649,6 +650,8 @@ class ChangeEmployeeRole(AuthenticatedMutation):
         if current_user.id == employment.user_id:
             raise UserSelfChangeRoleError
         employment.has_admin_rights = has_admin_rights
+        if not has_admin_rights:
+            remove_admin_from_teams(employment.user_id)
         db.session.commit()
         return employment
 

--- a/app/domain/team.py
+++ b/app/domain/team.py
@@ -1,8 +1,10 @@
+from app import db
 from app.models import User, CompanyKnownAddress, Vehicle, Employment
 from app.models.team import Team
 from app.models.team_association_tables import (
     team_vehicle_association_table,
     team_known_address_association_table,
+    team_admin_user_association_table,
 )
 
 
@@ -73,3 +75,17 @@ def remove_known_address_from_all_teams(company_known_address):
     )
     for team in teams_with_known_address:
         team.known_addresses.remove(company_known_address)
+
+
+def remove_admin_from_teams(admin_user_id):
+    admin_user = User.query.get(admin_user_id)
+    if not admin_user:
+        return
+    team_ids = (
+        db.session.query(team_admin_user_association_table.c.team_id)
+        .filter(team_admin_user_association_table.c.user_id == admin_user_id)
+        .all()
+    )
+    for team_id in team_ids:
+        team_to_update = Team.query.get(team_id[0])
+        team_to_update.admin_users.remove(admin_user)

--- a/app/tests/helpers.py
+++ b/app/tests/helpers.py
@@ -224,6 +224,25 @@ class ApiRequests:
         }
     """
 
+    change_employee_team = """
+        mutation changeEmployeeTeam($employmentId: Int!, $teamId: Int!) {
+            employments {
+              changeEmployeeTeam(
+                employmentId: $employmentId
+                teamId: $teamId
+              ) {
+                id
+                teams {
+                    name
+                    users {
+                        id
+                    }
+                }
+              }
+            }
+        }
+    """
+
     terminate_employment = """
         mutation terminateEmployment($employmentId: Int!, $endDate: Date) {
             employments {


### PR DESCRIPTION
- When creating an employment we can specify a team
- New mutation ChangeEmployeeTeam
- When an admin is no longer an admin, remove him from userAdmins of all teams