### PR TITLE
chore: fix dependencies to setup

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -17,7 +17,7 @@ blinker==1.4
 cached-property==1.5.1
 cachetools==4.2.2
 certifi==2019.11.28
-cffi==1.14.2
+cffi==1.14.6
 cfgv==2.0.1
 chardet==3.0.4
 charset-normalizer==2.0.6
@@ -110,7 +110,7 @@ python-editor==1.0.4
 python-utils==3.3.3
 pytz==2019.3
 PyYAML==5.4
-regex==2020.1.8
+regex==2022.10.31
 reportlab==3.6.6
 requests==2.26.0
 requests-oauthlib==1.3.0


### PR DESCRIPTION
Suite à mon upgrade de distri, j'ai du réinstallé mon environnement local python et j'ai eu des soucis avec l'installation de certaines dépendances, réglé par l'upgrade de versions :
* Pour `cffi` c'est clairement expliqué dans leur changelog : https://cffi.readthedocs.io/en/latest/whatsnew.html#v1-14-4 et j'ai mis les autres mineures parce que ça fix des bugs.
* Pour `regex` j'ai carément mis la dernière version car je pense qu'il y a peu de chance que ça casse des choses : https://github.com/mrabarnett/mrab-regex/tags 

