### PR TITLE
Feat: add company stats

### DIFF
--- a/app/commands.py
+++ b/app/commands.py
@@ -157,7 +157,7 @@ def _clean_vehicle():
 
 @app.cli.command()
 def clean_vehicle():
-    print(f"Cleaning the duplicate vehicles")
+    print("Cleaning the duplicate vehicles")
     _clean_vehicle()
 
 
@@ -285,3 +285,12 @@ def command_send_never_active_companies_emails():
 
     send_never_active_companies_emails(datetime.datetime.now())
     app.logger.info("Ending send_lost_companies_emails task")
+
+
+@app.cli.command("load_company_stats", with_appcontext=True)
+def load_company_stats():
+    from app.services.load_company_stats import load_company_stats
+
+    app.logger.info("Process load_company_stats began")
+    load_company_stats()
+    app.logger.info("Process load_company_stats done")

--- a/app/models/__init__.py
+++ b/app/models/__init__.py
@@ -4,6 +4,7 @@ from .company import Company
 from .address import Address
 from .company_known_address import CompanyKnownAddress
 from .company_certification import CompanyCertification
+from .company_stats import CompanyStats
 from .vehicle import Vehicle
 from .mission import Mission
 from .location_entry import LocationEntry

--- a/app/models/company_stats.py
+++ b/app/models/company_stats.py
@@ -1,0 +1,17 @@
+from app import db
+from app.models.base import BaseModel
+
+
+class CompanyStats(BaseModel):
+    company_id = db.Column(
+        db.Integer,
+        db.ForeignKey("company.id"),
+        index=True,
+        unique=True,
+        nullable=False,
+    )
+    company_creation_date = db.Column(db.Date, nullable=False)
+    first_employee_invitation_date = db.Column(db.Date, nullable=True)
+    first_mission_validation_by_admin_date = db.Column(db.Date, nullable=True)
+    first_active_criteria_date = db.Column(db.Date, nullable=True)
+    first_certification_date = db.Column(db.Date, nullable=True)

--- a/app/models/company_stats.py
+++ b/app/models/company_stats.py
@@ -10,8 +10,12 @@ class CompanyStats(BaseModel):
         unique=True,
         nullable=False,
     )
-    company_creation_date = db.Column(db.Date, nullable=False)
-    first_employee_invitation_date = db.Column(db.Date, nullable=True)
-    first_mission_validation_by_admin_date = db.Column(db.Date, nullable=True)
-    first_active_criteria_date = db.Column(db.Date, nullable=True)
-    first_certification_date = db.Column(db.Date, nullable=True)
+    company_creation_date = db.Column(db.Date, nullable=False, index=True)
+    first_employee_invitation_date = db.Column(
+        db.Date, nullable=True, index=True
+    )
+    first_mission_validation_by_admin_date = db.Column(
+        db.Date, nullable=True, index=True
+    )
+    first_active_criteria_date = db.Column(db.Date, nullable=True, index=True)
+    first_certification_date = db.Column(db.Date, nullable=True, index=True)

--- a/app/seed/__init__.py
+++ b/app/seed/__init__.py
@@ -14,6 +14,7 @@ from app.models import (
     Company,
     CompanyCertification,
     CompanyKnownAddress,
+    CompanyStats,
     ControllerRefreshToken,
     ControllerUser,
     Email,
@@ -80,6 +81,7 @@ def clean():
         """
     )
 
+    CompanyStats.query.delete()
     CompanyCertification.query.delete()
     CompanyKnownAddress.query.delete()
     Employment.query.delete()

--- a/app/services/load_company_stats.py
+++ b/app/services/load_company_stats.py
@@ -47,7 +47,11 @@ def get_first_mission_validation_by_admin_date(company_id):
     return (
         db.session.query(db.func.min(MissionValidation.creation_time))
         .join(Mission)
-        .filter(Mission.company_id == company_id, MissionValidation.is_admin)
+        .filter(
+            Mission.company_id == company_id,
+            MissionValidation.is_admin,
+            Mission.user_id != Mission.submitter_id,
+        )
         .first()
     )
 

--- a/app/services/load_company_stats.py
+++ b/app/services/load_company_stats.py
@@ -40,7 +40,7 @@ def get_first_employee_invitation_date(company_id):
             Employment.company_id == company_id, ~Employment.has_admin_rights
         )
         .first()
-    )
+    )[0]
 
 
 def get_first_mission_validation_by_admin_date(company_id):
@@ -50,10 +50,10 @@ def get_first_mission_validation_by_admin_date(company_id):
         .filter(
             Mission.company_id == company_id,
             MissionValidation.is_admin,
-            Mission.user_id != Mission.submitter_id,
+            MissionValidation.user_id != MissionValidation.submitter_id,
         )
         .first()
-    )
+    )[0]
 
 
 def get_first_active_criteria_date(company_id):
@@ -64,7 +64,7 @@ def get_first_active_criteria_date(company_id):
             CompanyCertification.be_active,
         )
         .first()
-    )
+    )[0]
 
 
 def get_first_certification_date(company_id):
@@ -79,7 +79,7 @@ def get_first_certification_date(company_id):
             CompanyCertification.log_in_real_time,
         )
         .first()
-    )
+    )[0]
 
 
 STEPS = {

--- a/app/services/load_company_stats.py
+++ b/app/services/load_company_stats.py
@@ -1,0 +1,86 @@
+from app import db
+from app.models.company import Company
+from app.models.company_certification import CompanyCertification
+from app.models.company_stats import CompanyStats
+from app.models.employment import Employment
+from app.models.mission_validation import MissionValidation
+from app.models.mission import Mission
+
+
+def load_company_stats():
+    companies = Company.query.all()
+    for company in companies:
+        company_stats = get_or_init_company_stats(company)
+        for field, check in STEPS.items():
+            if getattr(company_stats, field) is None:
+                step_result = check(company.id)
+                if step_result is None:
+                    break
+                else:
+                    setattr(company_stats, field, step_result)
+        db.session.add(company_stats)
+        db.session.commit()
+
+
+def get_or_init_company_stats(company):
+    company_stats = CompanyStats.query.filter(
+        CompanyStats.company_id == company.id
+    ).one_or_none()
+    if company_stats is None:
+        company_stats = CompanyStats(
+            company_id=company.id, company_creation_date=company.creation_time
+        )
+    return company_stats
+
+
+def get_first_employee_invitation_date(company_id):
+    return (
+        db.session.query(db.func.min(Employment.creation_time))
+        .filter(
+            Employment.company_id == company_id, ~Employment.has_admin_rights
+        )
+        .first()
+    )
+
+
+def get_first_mission_validation_by_admin_date(company_id):
+    return (
+        db.session.query(db.func.min(MissionValidation.creation_time))
+        .join(Mission)
+        .filter(Mission.company_id == company_id, MissionValidation.is_admin)
+        .first()
+    )
+
+
+def get_first_active_criteria_date(company_id):
+    return (
+        db.session.query(db.func.min(CompanyCertification.attribution_date))
+        .filter(
+            CompanyCertification.company_id == company_id,
+            CompanyCertification.be_active,
+        )
+        .first()
+    )
+
+
+def get_first_certification_date(company_id):
+    return (
+        db.session.query(db.func.min(CompanyCertification.attribution_date))
+        .filter(
+            CompanyCertification.company_id == company_id,
+            CompanyCertification.be_active,
+            CompanyCertification.be_compliant,
+            CompanyCertification.not_too_many_changes,
+            CompanyCertification.validate_regularly,
+            CompanyCertification.log_in_real_time,
+        )
+        .first()
+    )
+
+
+STEPS = {
+    "first_employee_invitation_date": get_first_employee_invitation_date,
+    "first_mission_validation_by_admin_date": get_first_mission_validation_by_admin_date,
+    "first_active_criteria_date": get_first_active_criteria_date,
+    "first_certification_date": get_first_certification_date,
+}

--- a/app/tests/test_load_company_stats.py
+++ b/app/tests/test_load_company_stats.py
@@ -1,0 +1,44 @@
+from app import db
+from app.models.company_stats import CompanyStats
+from app.seed import CompanyFactory
+from app.services.load_company_stats import load_company_stats
+from app.tests import BaseTest
+
+
+class TestLoadCompanyStats(BaseTest):
+    def get_stats_for_company(self, company_id):
+        return CompanyStats.query.filter(
+            CompanyStats.company_id == company_id
+        ).one_or_none()
+
+    def setUp(self):
+        super().setUp()
+
+    def test_new_company(self):
+        new_company = CompanyFactory.create()
+
+        load_company_stats()
+        db.session.expire_all()
+
+        company_stats = self.get_stats_for_company(new_company.id)
+        self.assertIsNotNone(company_stats)
+        self.assertEqual(
+            company_stats.company_creation_date,
+            new_company.creation_time.date(),
+        )
+
+    def test_existing_company(self):
+        existing_company = CompanyFactory.create()
+        existing_company_stats = CompanyStats(
+            company_id=existing_company.id,
+            company_creation_date=existing_company.creation_time,
+            first_employee_invitation_date=existing_company.creation_time,
+        )
+        db.session.add(existing_company_stats)
+        db.session.commit()
+
+        load_company_stats()
+        db.session.expire_all()
+
+        company_stats = self.get_stats_for_company(existing_company.id)
+        self.assertIsNotNone(company_stats)

--- a/cron.json
+++ b/cron.json
@@ -8,6 +8,9 @@
     },
     {
       "command": "30 3 * * * flask send_never_active_companies_emails"
+    },
+    {
+      "command": "0 5 1 * * flask load_company_stats"
     }
   ]
 }

--- a/migrations/versions/27655467d715_add_company_stats.py
+++ b/migrations/versions/27655467d715_add_company_stats.py
@@ -1,0 +1,50 @@
+"""add company stats
+
+Revision ID: 27655467d715
+Revises: b93eeb578bdd
+Create Date: 2023-08-24 17:09:50.589698
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = "27655467d715"
+down_revision = "b93eeb578bdd"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.create_table(
+        "company_stats",
+        sa.Column("creation_time", sa.DateTime(), nullable=False),
+        sa.Column("company_id", sa.Integer(), nullable=False),
+        sa.Column("company_creation_date", sa.Date(), nullable=False),
+        sa.Column("first_employee_invitation_date", sa.Date(), nullable=True),
+        sa.Column(
+            "first_mission_validation_by_admin_date", sa.Date(), nullable=True
+        ),
+        sa.Column("first_active_criteria_date", sa.Date(), nullable=True),
+        sa.Column("first_certification_date", sa.Date(), nullable=True),
+        sa.Column("id", sa.Integer(), nullable=False),
+        sa.ForeignKeyConstraint(
+            ["company_id"],
+            ["company.id"],
+        ),
+        sa.PrimaryKeyConstraint("id"),
+    )
+    op.create_index(
+        op.f("ix_company_stats_company_id"),
+        "company_stats",
+        ["company_id"],
+        unique=True,
+    )
+
+
+def downgrade():
+    op.drop_index(
+        op.f("ix_company_stats_company_id"), table_name="company_stats"
+    )
+    op.drop_table("company_stats")

--- a/migrations/versions/27655467d715_add_company_stats.py
+++ b/migrations/versions/27655467d715_add_company_stats.py
@@ -1,7 +1,7 @@
 """add company stats
 
 Revision ID: 27655467d715
-Revises: b93eeb578bdd
+Revises: aa3c6ff8cdb7
 Create Date: 2023-08-24 17:09:50.589698
 
 """
@@ -11,7 +11,7 @@ import sqlalchemy as sa
 
 # revision identifiers, used by Alembic.
 revision = "27655467d715"
-down_revision = "b93eeb578bdd"
+down_revision = "aa3c6ff8cdb7"
 branch_labels = None
 depends_on = None
 
@@ -41,10 +41,60 @@ def upgrade():
         ["company_id"],
         unique=True,
     )
+    op.create_index(
+        op.f("ix_company_stats_company_creation_date"),
+        "company_stats",
+        ["company_creation_date"],
+        unique=False,
+    )
+    op.create_index(
+        op.f("ix_company_stats_first_active_criteria_date"),
+        "company_stats",
+        ["first_active_criteria_date"],
+        unique=False,
+    )
+    op.create_index(
+        op.f("ix_company_stats_first_certification_date"),
+        "company_stats",
+        ["first_certification_date"],
+        unique=False,
+    )
+    op.create_index(
+        op.f("ix_company_stats_first_employee_invitation_date"),
+        "company_stats",
+        ["first_employee_invitation_date"],
+        unique=False,
+    )
+    op.create_index(
+        op.f("ix_company_stats_first_mission_validation_by_admin_date"),
+        "company_stats",
+        ["first_mission_validation_by_admin_date"],
+        unique=False,
+    )
 
 
 def downgrade():
     op.drop_index(
         op.f("ix_company_stats_company_id"), table_name="company_stats"
+    )
+    op.drop_index(
+        op.f("ix_company_stats_first_mission_validation_by_admin_date"),
+        table_name="company_stats",
+    )
+    op.drop_index(
+        op.f("ix_company_stats_first_employee_invitation_date"),
+        table_name="company_stats",
+    )
+    op.drop_index(
+        op.f("ix_company_stats_first_certification_date"),
+        table_name="company_stats",
+    )
+    op.drop_index(
+        op.f("ix_company_stats_first_active_criteria_date"),
+        table_name="company_stats",
+    )
+    op.drop_index(
+        op.f("ix_company_stats_company_creation_date"),
+        table_name="company_stats",
     )
     op.drop_table("company_stats")


### PR DESCRIPTION
https://trello.com/c/lznexqvm/969-mesure-dimpact-n2-churn-gestionnaire

- [x] Tester avec beaucoup de données
- [x] Ajouter un test automatique
- [x] Ajouter des index sur les dates
- [x] Ajouter `where user_id != submitter_id` sur le check "onboarding"

Temps d'exécution sur équivalent prod : 
- sans index : `flask load_company_stats  9,66s user 0,45s system 38% cpu 26,222 total`
- avec index : `flask load_company_stats  10,19s user 0,50s system 45% cpu 23,472 total`