### PR TITLE
fix(infractions): assume utc datetime in db and convert extra fields to user timezone

### DIFF
--- a/app/data_access/control_data.py
+++ b/app/data_access/control_data.py
@@ -10,6 +10,7 @@ from app.data_access.mission import MissionOutput
 from app.data_access.regulation_computation import (
     RegulationComputationByDayOutput,
 )
+from app.domain.control_data import convert_extra_datetime_to_user_tz
 from app.domain.regulation_computations import get_regulation_computations
 from app.domain.regulations_per_day import NATINF_32083
 from app.helpers.graphene_types import (
@@ -183,6 +184,9 @@ class ControllerControlOutput(BaseSQLAlchemyObjectType):
                 label = label.replace("quotidien", "de nuit")
                 description = f"{description}. Si une partie du travail de la journée s'effectue entre minuit et 5 heures, la durée maximale du travail est réduite à 10 heures"
 
+            extra = infraction.get("extra")
+            convert_extra_datetime_to_user_tz(extra, self.user_id)
+
             observed_infractions.append(
                 ObservedInfraction(
                     sanction=sanction,
@@ -195,7 +199,7 @@ class ControllerControlOutput(BaseSQLAlchemyObjectType):
                     description=description,
                     type=infraction.get("check_type"),
                     unit=infraction.get("check_unit"),
-                    extra=infraction.get("extra"),
+                    extra=extra,
                 )
             )
         return observed_infractions

--- a/app/domain/control_data.py
+++ b/app/domain/control_data.py
@@ -20,7 +20,7 @@ def convert_extra_datetime_to_user_tz(extra, user_id):
     timezone = pytz.timezone(controlled_user.timezone_name)
 
     for key in EXTRA_DATETIME_FIELDS:
-        if not key in extra:
+        if key not in extra:
             continue
         datetime_utc_str = extra.get(key)
         datetime_utc = datetime.datetime.fromisoformat(

--- a/app/domain/control_data.py
+++ b/app/domain/control_data.py
@@ -1,0 +1,30 @@
+import datetime
+import pytz
+from app.models import User
+
+EXTRA_DATETIME_FIELDS = [
+    "breach_period_start",
+    "breach_period_end",
+    "work_range_start",
+    "work_range_end",
+    "longest_uninterrupted_work_start",
+    "longest_uninterrupted_work_end",
+]
+
+
+def convert_extra_datetime_to_user_tz(extra, user_id):
+    if not any(key in extra for key in EXTRA_DATETIME_FIELDS):
+        return
+
+    controlled_user = User.query.filter(User.id == user_id).one()
+    timezone = pytz.timezone(controlled_user.timezone_name)
+
+    for key in EXTRA_DATETIME_FIELDS:
+        if not key in extra:
+            continue
+        datetime_utc_str = extra.get(key)
+        datetime_utc = datetime.datetime.fromisoformat(
+            datetime_utc_str
+        ).replace(tzinfo=datetime.timezone.utc)
+        datetime_tz = datetime_utc.astimezone(timezone)
+        extra[key] = datetime_tz.strftime("%Y-%m-%dT%H:%M:%S")


### PR DESCRIPTION
https://trello.com/c/Tcsamow5/1235-bug-d%C3%A9calage-horaire-2h-dans-le-relev%C3%A9-des-infractions

I have assumed db datetime fields to be utc, so it introduces a bug with data generated locally. Should we do better ?