### PR TITLE
chore: increase gunicorn timeout

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,4 +1,4 @@
-web: gunicorn app:app --preload --workers=2
+web: gunicorn app:app --preload --workers=2 --timeout=120
 release: flask db upgrade
 postdeploy: flask db upgrade
 


### PR DESCRIPTION
from 30 (default) to 120 seconds