### PR TITLE
Fix/mission too long

### DIFF
--- a/app/controllers/mission.py
+++ b/app/controllers/mission.py
@@ -1,6 +1,7 @@
+from datetime import datetime
+
 import graphene
 from graphene.types.generic import GenericScalar
-from datetime import datetime
 from sqlalchemy.orm import selectinload
 
 from app import app, db
@@ -11,38 +12,37 @@ from app.controllers.expenditure import (
     log_expenditure_,
 )
 from app.controllers.utils import atomic_transaction
+from app.data_access.mission import MissionOutput
 from app.domain.notifications import (
     warn_if_mission_changes_since_latest_user_action,
 )
-from app.domain.validation import validate_mission
+from app.domain.permissions import (
+    check_actor_can_write_on_mission,
+    get_employment_over_period,
+    can_actor_read_mission,
+    company_admin,
+    check_actor_can_write_on_mission_for_user,
+)
+from app.domain.validation import (
+    validate_mission,
+    pre_check_validate_mission_by_admin,
+)
 from app.domain.vehicle import find_or_create_vehicle
+from app.helpers.authentication import current_user, AuthenticatedMutation
 from app.helpers.authorization import (
     with_authorization_policy,
     active,
     check_company_against_scope_wrapper,
 )
-from app.helpers.graphene_types import TimeStamp
-from app.models.mission import Mission
-from app.models import Company, Vehicle, User, Activity
-from app.models.mission_end import MissionEnd
-from app.models.mission_validation import (
-    MissionValidationOutput,
-)
-from app.data_access.mission import MissionOutput
-from app.domain.permissions import (
-    check_actor_can_write_on_mission,
-    get_employment_over_period,
-    is_employed_by_company_over_period,
-    can_actor_read_mission,
-    company_admin,
-    check_actor_can_write_on_mission_for_user,
-)
-from app.helpers.authentication import current_user, AuthenticatedMutation
 from app.helpers.errors import (
     AuthorizationError,
     MissionAlreadyEndedError,
     UnavailableSwitchModeError,
 )
+from app.helpers.graphene_types import TimeStamp
+from app.models import Company, User, Activity
+from app.models.mission import Mission
+from app.models.mission_end import MissionEnd
 from app.models.vehicle import VehicleOutput
 
 
@@ -297,6 +297,18 @@ class ValidateMission(AuthenticatedMutation):
         expenditures_cancel_ids=[],
         expenditures_inputs=[],
     ):
+        mission = Mission.query.get(mission_id)
+        is_admin_validation = company_admin(current_user, mission.company_id)
+
+        if is_admin_validation:
+            for user_id in users_ids:
+                user = User.query.get(user_id)
+                pre_check_validate_mission_by_admin(
+                    mission=mission,
+                    admin_submitter=current_user,
+                    for_user=user,
+                )
+
         with atomic_transaction(commit_at_end=True):
             play_bulk_activity_items(activity_items)
 
@@ -305,8 +317,6 @@ class ValidateMission(AuthenticatedMutation):
 
             for expenditure_input in expenditures_inputs:
                 log_expenditure_(expenditure_input)
-
-            mission = Mission.query.get(mission_id)
 
             for user_id in users_ids:
                 user = User.query.get(user_id)

--- a/app/domain/validation.py
+++ b/app/domain/validation.py
@@ -19,6 +19,36 @@ MIN_MISSION_LIFETIME_FOR_ADMIN_FORCE_VALIDATION = timedelta(days=10)
 MIN_LAST_ACTIVITY_LIFETIME_FOR_ADMIN_FORCE_VALIDATION = timedelta(hours=24)
 
 
+# In case an admin wants to validate a mission for an employee who did not yet validate its mission
+# He should not be able to do it, except for two special cases
+def pre_check_validate_mission_by_admin(mission, admin_submitter, for_user):
+    activities_to_validate = mission.activities_for(for_user)
+
+    # Checks if employee has already validated its mission
+    if len(mission.validations_for(for_user)) > 0:
+        return
+
+    # Evacuates case where admin is validating for himself
+    if (
+        for_user.id == admin_submitter.id
+        or mission.submitter_id == admin_submitter.id
+    ):
+        return
+
+    mission_start = activities_to_validate[0].start_time
+    last_activity_start = activities_to_validate[-1].start_time
+    mission_old_enough = (
+        datetime.now() - mission_start
+        > MIN_MISSION_LIFETIME_FOR_ADMIN_FORCE_VALIDATION
+    )
+    last_activity_long_enough = (
+        datetime.now() - last_activity_start
+        > MIN_LAST_ACTIVITY_LIFETIME_FOR_ADMIN_FORCE_VALIDATION
+    )
+    if not (mission_old_enough or last_activity_long_enough):
+        raise MissionNotAlreadyValidatedByUserError()
+
+
 def validate_mission(mission, submitter, for_user, creation_time=None):
     validation_time = datetime.now()
     is_admin_validation = company_admin(submitter, mission.company_id)
@@ -37,25 +67,6 @@ def validate_mission(mission, submitter, for_user, creation_time=None):
 
     if any([not a.end_time for a in activities_to_validate]):
         raise MissionStillRunningError()
-
-    if (
-        is_admin_validation
-        and for_user.id != submitter.id
-        and mission.submitter_id != submitter.id
-        and len(mission.validations_for(for_user)) == 0
-    ):
-        mission_start = activities_to_validate[0].start_time
-        last_activity_start = activities_to_validate[-1].start_time
-        mission_old_enough = (
-            datetime.now() - mission_start
-            > MIN_MISSION_LIFETIME_FOR_ADMIN_FORCE_VALIDATION
-        )
-        last_activity_long_enough = (
-            datetime.now() - last_activity_start
-            > MIN_LAST_ACTIVITY_LIFETIME_FOR_ADMIN_FORCE_VALIDATION
-        )
-        if not (mission_old_enough or last_activity_long_enough):
-            raise MissionNotAlreadyValidatedByUserError()
 
     if not mission.ended_for(for_user):
         db.session.add(


### PR DESCRIPTION
An admin can not validate a mission from one of its employee if the employee has not yet validated, except for two special cases:
- the mission was started more than 10 days ago
- the mission has an activity **still running** (added in this PR) and started more than 24h ago 

We determine if one of this special case is true **before** applying modifications made by admin in the process of validating the mission.