### PR TITLE
fix(regulations): mark first day of week as computed when computing regulations

### DIFF
--- a/app/domain/regulations.py
+++ b/app/domain/regulations.py
@@ -96,6 +96,7 @@ def compute_regulations(
     )
     for week in weeks:
         compute_regulations_per_week(user, business, week, submitter_type)
+        mark_day_as_computed(user, week.get("start"), submitter_type)
 
 
 def activity_to_compute_in_day(

--- a/app/tests/regulations/test_common.py
+++ b/app/tests/regulations/test_common.py
@@ -181,8 +181,8 @@ class TestRegulationsCommon(RegulationsTest):
             submitter=self.employee,
             work_periods=[
                 [
-                    get_time(how_many_days_ago=18, hour=4),
-                    get_time(how_many_days_ago=3, hour=5),
+                    get_datetime_tz(2024, 7, 25, 4, 0),
+                    get_datetime_tz(2024, 8, 9, 5, 0),
                 ],
             ],
         )
@@ -194,4 +194,4 @@ class TestRegulationsCommon(RegulationsTest):
             RegulationComputation.user.has(User.email == EMPLOYEE_EMAIL),
             RegulationComputation.submitter_type == SubmitterType.EMPLOYEE,
         ).all()
-        self.assertEqual(len(computations_done), 16)
+        self.assertEqual(len(computations_done), 17)

--- a/app/tests/regulations/test_weekly_rules.py
+++ b/app/tests/regulations/test_weekly_rules.py
@@ -5,7 +5,13 @@ from app.domain.log_activities import log_activity
 from app.domain.regulations_per_week import NATINF_13152
 from app.domain.validation import validate_mission
 from app.helpers.submitter_type import SubmitterType
-from app.models import RegulatoryAlert, User, RegulationCheck, Mission
+from app.models import (
+    RegulatoryAlert,
+    User,
+    RegulationCheck,
+    Mission,
+    RegulationComputation,
+)
 from app.models.activity import ActivityType
 from app.models.regulation_check import RegulationCheckType
 from app.seed.helpers import (
@@ -214,3 +220,35 @@ class TestWeeklyRules(RegulationsTest):
         self.assertFalse(extra_info["too_many_days"])
         self.assertEqual(extra_info["rest_duration_s"], 111600)
         self.assertEqual(extra_info["sanction_code"], NATINF_13152)
+
+    def test_weekly_rule_should_mark_beginning_of_week_as_computed(self):
+
+        self._log_and_validate_mission(
+            mission_name="Work on end of weeks",
+            submitter=self.employee,
+            work_periods=[
+                [
+                    get_datetime_tz(2024, 8, 2, 8, 0),
+                    get_datetime_tz(2024, 8, 2, 18, 0),
+                ],
+                [
+                    get_datetime_tz(2024, 8, 9, 8, 0),
+                    get_datetime_tz(2024, 8, 9, 18, 0),
+                ],
+            ],
+        )
+
+        # Should have regulation computations on mondays
+        res = RegulationComputation.query.filter(
+            RegulationComputation.user.has(User.email == EMPLOYEE_EMAIL),
+            RegulationComputation.day == date(2024, 8, 5),
+            RegulationComputation.submitter_type == SubmitterType.EMPLOYEE,
+        ).one_or_none()
+        self.assertIsNotNone(res)
+
+        res = RegulationComputation.query.filter(
+            RegulationComputation.user.has(User.email == EMPLOYEE_EMAIL),
+            RegulationComputation.day == date(2024, 7, 29),
+            RegulationComputation.submitter_type == SubmitterType.EMPLOYEE,
+        ).one_or_none()
+        self.assertIsNotNone(res)


### PR DESCRIPTION
https://trello.com/c/qiTS0eJL/1591-des-alertes-hebdomadaires-ne-remontent-pas-sil-ny-a-pas-eu-de-missions-valid%C3%A9es-en-d%C3%A9but-de-semaine