### PR TITLE
feat(control_history): change depth history to 56 days

### DIFF
--- a/app/tests/controls/test_read_control_data.py
+++ b/app/tests/controls/test_read_control_data.py
@@ -54,7 +54,7 @@ class TestReadControlData(ControlsTestSimple):
 
     def test_can_read_alerts(self):
         RegulationComputationFactory.create(
-            day=get_date(how_many_days_ago=30),
+            day=get_date(how_many_days_ago=60),
             submitter_type=SubmitterType.EMPLOYEE,
             user=self.controlled_user_1,
         )

--- a/app/tests/regulations/test_report_infractions.py
+++ b/app/tests/regulations/test_report_infractions.py
@@ -46,7 +46,7 @@ class TestReportInfractions(RegulationsTest):
             controller_id=controller_user.id,
             company_name=self.company.name,
             vehicle_registration_number="AAA 11 BBB",
-            nb_controlled_days=56,
+            nb_controlled_days=28,
         )
         db.session.add(new_control)
         db.session.commit()

--- a/app/tests/regulations/test_report_infractions.py
+++ b/app/tests/regulations/test_report_infractions.py
@@ -46,7 +46,7 @@ class TestReportInfractions(RegulationsTest):
             controller_id=controller_user.id,
             company_name=self.company.name,
             vehicle_registration_number="AAA 11 BBB",
-            nb_controlled_days=28,
+            nb_controlled_days=56,
         )
         db.session.add(new_control)
         db.session.commit()

--- a/config.py
+++ b/config.py
@@ -64,7 +64,7 @@ class Config:
         "USER_READ_TOKEN_EXPIRATION", timedelta(days=7)
     )
     HMAC_SIGNING_KEY = os.environ.get("HMAC_SIGNING_KEY")
-    USER_CONTROL_HISTORY_DEPTH = timedelta(days=28)
+    USER_CONTROL_HISTORY_DEPTH = timedelta(days=56)
     MIN_DELAY_BETWEEN_INVITATION_EMAILS = timedelta(
         minutes=os.environ.get(
             "MIN_MINUTES_BETWEEN_INVITATION_EMAILS", 60 * 24

--- a/config.py
+++ b/config.py
@@ -64,7 +64,9 @@ class Config:
         "USER_READ_TOKEN_EXPIRATION", timedelta(days=7)
     )
     HMAC_SIGNING_KEY = os.environ.get("HMAC_SIGNING_KEY")
-    USER_CONTROL_HISTORY_DEPTH = timedelta(days=56)
+    USER_CONTROL_HISTORY_DEPTH = timedelta(
+        days=os.environ.get("USER_CONTROL_HISTORY_DEPTH", 28)
+    )
     MIN_DELAY_BETWEEN_INVITATION_EMAILS = timedelta(
         minutes=os.environ.get(
             "MIN_MINUTES_BETWEEN_INVITATION_EMAILS", 60 * 24


### PR DESCRIPTION
**:warning: Variable d'environnement à mettre pour la MEP :  USER_CONTROL_HISTORY_DEPTH=56** 

[PR FRONT](https://github.com/MTES-MCT/mobilic/pull/615)

https://trello.com/c/DV54hcgG/1670-faire-passer-le-nombre-de-jours-contr%C3%B4l%C3%A9s-%C3%A0-56