### PR TITLE
fix(bizdev): send no invitation email reminder D+7 instead of D+15

### DIFF
--- a/app/jobs/emails/bizdev/send_companies_without_any_employee_invitation_emails.py
+++ b/app/jobs/emails/bizdev/send_companies_without_any_employee_invitation_emails.py
@@ -6,7 +6,7 @@ from app.domain.company import (
 )
 from app.jobs import log_execution
 
-NB_DAYS_AGO = 14
+NB_DAYS_AGO = 6
 
 
 @log_execution


### PR DESCRIPTION
https://trello.com/c/g1GIqKk8/1923-modifier-la-fréquence-denvoi-du-mail-de-relance-automatique-envoyé-aux-gestionnaires-nayant-invité-aucun-salarié