### PR TITLE
fix(anonymisation): correct migration head

### DIFF
--- a/migrations/versions/460f372be359_add_anonymized_table_and_mapping_id.py
+++ b/migrations/versions/460f372be359_add_anonymized_table_and_mapping_id.py
@@ -12,7 +12,7 @@ from app.models.user import UserAccountStatus
 
 # revision identifiers, used by Alembic.
 revision = "460f372be359"
-down_revision = "fc7fb77ff350"
+down_revision = "44bebfc43b10"
 branch_labels = None
 depends_on = None
 


### PR DESCRIPTION
Migration have been add without using the anonymisation migration head as reference so a fixed is needed : 

alembic.util.exc.CommandError: Multiple head revisions are present for given argument 'head'; please specify a specific target revision, '<branchname>@head' to narrow to a specific head, or 'heads' for all heads