### PR TITLE
Handle clock change on tests

### DIFF
--- a/app/tests/regulations/test_daily_rest.py
+++ b/app/tests/regulations/test_daily_rest.py
@@ -457,45 +457,60 @@ class TestDailyRest(RegulationsTest):
         )
 
     def test_night_worker(self):
-        how_many_days_ago = 3
-        self._log_and_validate_mission(
-            mission_name="Mission de nuit",
-            submitter=self.employee,
-            work_periods=[
-                [
-                    get_time(how_many_days_ago=how_many_days_ago, hour=20),
-                    get_time(how_many_days_ago=how_many_days_ago, hour=23),
+        # freeze date out of clock change day to avoid errors when it happens
+        with freeze_time(date(2025, 4, 5)):
+            how_many_days_ago = 3
+            self._log_and_validate_mission(
+                mission_name="Mission de nuit",
+                submitter=self.employee,
+                work_periods=[
+                    [
+                        get_time(how_many_days_ago=how_many_days_ago, hour=20),
+                        get_time(how_many_days_ago=how_many_days_ago, hour=23),
+                    ],
+                    [
+                        get_time(
+                            how_many_days_ago=how_many_days_ago - 1, hour=1
+                        ),
+                        get_time(
+                            how_many_days_ago=how_many_days_ago - 1, hour=5
+                        ),
+                    ],
+                    [
+                        get_time(
+                            how_many_days_ago=how_many_days_ago - 1, hour=7
+                        ),
+                        get_time(
+                            how_many_days_ago=how_many_days_ago - 1, hour=11
+                        ),
+                    ],
+                    [
+                        get_time(
+                            how_many_days_ago=how_many_days_ago - 1, hour=13
+                        ),
+                        get_time(
+                            how_many_days_ago=how_many_days_ago - 1, hour=19
+                        ),
+                    ],
                 ],
-                [
-                    get_time(how_many_days_ago=how_many_days_ago - 1, hour=1),
-                    get_time(how_many_days_ago=how_many_days_ago - 1, hour=5),
-                ],
-                [
-                    get_time(how_many_days_ago=how_many_days_ago - 1, hour=7),
-                    get_time(how_many_days_ago=how_many_days_ago - 1, hour=11),
-                ],
-                [
-                    get_time(how_many_days_ago=how_many_days_ago - 1, hour=13),
-                    get_time(how_many_days_ago=how_many_days_ago - 1, hour=19),
-                ],
-            ],
-        )
-        regulatory_alerts = RegulatoryAlert.query.filter(
-            RegulatoryAlert.user.has(User.email == EMPLOYEE_EMAIL),
-            RegulatoryAlert.regulation_check.has(
-                RegulationCheck.type == RegulationCheckType.MINIMUM_DAILY_REST
-            ),
-            RegulatoryAlert.submitter_type == SubmitterType.EMPLOYEE,
-        ).all()
-        self.assertEqual(2, len(regulatory_alerts))
+            )
+            regulatory_alerts = RegulatoryAlert.query.filter(
+                RegulatoryAlert.user.has(User.email == EMPLOYEE_EMAIL),
+                RegulatoryAlert.regulation_check.has(
+                    RegulationCheck.type
+                    == RegulationCheckType.MINIMUM_DAILY_REST
+                ),
+                RegulatoryAlert.submitter_type == SubmitterType.EMPLOYEE,
+            ).all()
+            self.assertEqual(2, len(regulatory_alerts))
 
-        extras = [ra.extra for ra in regulatory_alerts]
-        self.assertEquals(
-            2 * HOUR, extras[0].get("breach_period_max_break_in_seconds")
-        )
-        self.assertEquals(
-            6 * HOUR, extras[1].get("breach_period_max_break_in_seconds")
-        )
+            extras = [ra.extra for ra in regulatory_alerts]
+            self.assertEquals(
+                2 * HOUR, extras[0].get("breach_period_max_break_in_seconds")
+            )
+            self.assertEquals(
+                6 * HOUR, extras[1].get("breach_period_max_break_in_seconds")
+            )
 
     def test_night_worker_on_clock_change(self):
         # changed clock on night from 29th to 30th March 2025
@@ -510,23 +525,36 @@ class TestDailyRest(RegulationsTest):
                         get_time(how_many_days_ago=how_many_days_ago, hour=23),
                     ],
                     [
-                        get_time(how_many_days_ago=how_many_days_ago - 1, hour=1),
-                        get_time(how_many_days_ago=how_many_days_ago - 1, hour=5),
+                        get_time(
+                            how_many_days_ago=how_many_days_ago - 1, hour=1
+                        ),
+                        get_time(
+                            how_many_days_ago=how_many_days_ago - 1, hour=5
+                        ),
                     ],
                     [
-                        get_time(how_many_days_ago=how_many_days_ago - 1, hour=7),
-                        get_time(how_many_days_ago=how_many_days_ago - 1, hour=11),
+                        get_time(
+                            how_many_days_ago=how_many_days_ago - 1, hour=7
+                        ),
+                        get_time(
+                            how_many_days_ago=how_many_days_ago - 1, hour=11
+                        ),
                     ],
                     [
-                        get_time(how_many_days_ago=how_many_days_ago - 1, hour=13),
-                        get_time(how_many_days_ago=how_many_days_ago - 1, hour=19),
+                        get_time(
+                            how_many_days_ago=how_many_days_ago - 1, hour=13
+                        ),
+                        get_time(
+                            how_many_days_ago=how_many_days_ago - 1, hour=19
+                        ),
                     ],
                 ],
             )
             regulatory_alerts = RegulatoryAlert.query.filter(
                 RegulatoryAlert.user.has(User.email == EMPLOYEE_EMAIL),
                 RegulatoryAlert.regulation_check.has(
-                    RegulationCheck.type == RegulationCheckType.MINIMUM_DAILY_REST
+                    RegulationCheck.type
+                    == RegulationCheckType.MINIMUM_DAILY_REST
                 ),
                 RegulatoryAlert.submitter_type == SubmitterType.EMPLOYEE,
             ).all()


### PR DESCRIPTION
* Add a test to verify that alerts are correctly computed on clock change day
* Freeze time on a non clock change day for tests that will have a different result depending on that