### PR TITLE
fix(company): improve SIREN validation error messages for SIRET conflicts

### DIFF
--- a/app/controllers/company.py
+++ b/app/controllers/company.py
@@ -333,6 +333,14 @@ def store_company(
         and not sirets
     ):
         raise SirenAlreadySignedUpError()
+
+    if (
+        registration_status == SirenRegistrationStatus.FULLY_REGISTERED
+        and sirets
+    ):
+        raise SirenAlreadySignedUpError(
+            "Company already registered globally for this SIREN (representing all establishments). Cannot create SIRET-specific establishments."
+        )
     siren_api_info = None
     try:
         siren_api_info = siren_api_client.get_siren_info(siren)

--- a/app/domain/company.py
+++ b/app/domain/company.py
@@ -33,7 +33,10 @@ def get_siren_registration_status(siren):
     if not all_registered_companies_for_siren:
         return SirenRegistrationStatus.UNREGISTERED, None
     if any(
-        [c.short_sirets is None for c in all_registered_companies_for_siren]
+        [
+            c.short_sirets is None or c.short_sirets == []
+            for c in all_registered_companies_for_siren
+        ]
     ):
         return SirenRegistrationStatus.FULLY_REGISTERED, None
     registered_sirets = []


### PR DESCRIPTION
https://trello.com/c/tWKkGwDq/2181-api-etq-qu%C3%A9diteurs-tiers-je-ne-peux-pas-cr%C3%A9er-d%C3%A9tablissement-lorsque-une-entreprise-est-d%C3%A9j%C3%A0-enregistr%C3%A9-avec-le-siren-de-fa%C3%A7on-g
  
  