### PR TITLE
feat(api): add siren validation and explicit error message

### DIFF
--- a/app/controllers/company.py
+++ b/app/controllers/company.py
@@ -47,8 +47,7 @@ from app.helpers.graphene_types import graphene_enum_type, Email
 from app.helpers.mail import MailingContactList
 from app.helpers.siren import (
     has_ceased_activity_from_siren_info,
-    is_valid_siren,
-    get_siren_validation_error,
+    validate_siren,
 )
 from app.helpers.tachograph import (
     get_tachograph_archive_company,
@@ -107,8 +106,9 @@ class CompanySoftwareRegistration(graphene.Mutation):
         error_message="You do not have access to the provided client id",
     )
     def mutate(cls, _, info, client_id, usual_name, siren, siret=None):
-        if not is_valid_siren(siren):
-            raise InvalidParamsError(get_siren_validation_error(siren))
+        error = validate_siren(siren)
+        if error:
+            raise InvalidParamsError(error)
 
         with atomic_transaction(commit_at_end=True):
             company = create_company_by_third_party(usual_name, siren, siret)

--- a/app/helpers/siren.py
+++ b/app/helpers/siren.py
@@ -6,18 +6,23 @@ from app.helpers.errors import MobilicError
 from app.helpers.insee_tranche_effectifs import format_tranche_effectif
 
 
-def is_valid_siren(siren):
-    """Check if SIREN format is valid."""
-    return siren and len(siren) == 9 and siren.isdigit()
+def validate_siren(siren):
+    """
+    Validate SIREN format and return error message if invalid
 
+    Args:
+        siren: The SIREN string to validate
 
-def get_siren_validation_error(siren):
-    """Get validation error message for invalid SIREN."""
-    if not siren or len(siren) != 9:
-        return f"SIREN must be exactly 9 characters (received: {len(siren) if siren else 0})"
+    Returns:
+        str: Error message if invalid
+    """
+    if not siren:
+        return "SIREN is required (received: empty value)"
+    if len(siren) != 9:
+        return f"SIREN must be exactly 9 characters (received: {len(siren)})"
     if not siren.isdigit():
         return "SIREN must contain only digits"
-    return "SIREN is valid"
+    return
 
 
 class UnavailableSirenAPIError(MobilicError):


### PR DESCRIPTION
https://trello.com/c/YEGCzJVd/2195-api-rajout-dune-validation-du-siren-et-dun-message-derreur-explicite-en-cas-de-mauvais-format-9-caract%C3%A8re-num%C3%A9riques