### PR TITLE
fix(exports): defer set_transferred_data_date outside atomic_transaction

### DIFF
--- a/app/controllers/company.py
+++ b/app/controllers/company.py
@@ -901,14 +901,18 @@ def checkout_exports():
         exports_ready
     )
 
+    cgu_user_ids = []
     with atomic_transaction(commit_at_end=True):
         for ready in exports_ready:
             if ready.id in ready_exports_links:
                 ready.status = ExportStatus.DOWNLOADED
                 if ready.export_type == ExportType.REFUSED_CGU:
-                    UserAgreement.set_transferred_data_date(ready.user_id)
+                    cgu_user_ids.append(ready.user_id)
             else:
                 ready.status = ExportStatus.FAILED
+
+    for user_id in cgu_user_ids:
+        UserAgreement.set_transferred_data_date(user_id)
 
     return (
         jsonify(


### PR DESCRIPTION
https://trello.com/c/1RDMME9G

Calling set_transferred_data_date (which uses its own atomic_transaction) inside checkout_exports's atomic_transaction caused a nested transaction error (SQLAlchemy InvalidRequestError). 
Collect CGU user ids during the transaction and call set_transferred_data_date after the block closes.