### PR TITLE
chore(observability): instrument SQL timing per request for Sentry

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -2,7 +2,9 @@ import os
 import logging
 
 import sentry_sdk
+from sentry_sdk.integrations.flask import FlaskIntegration
 from sentry_sdk.integrations.logging import LoggingIntegration
+from sentry_sdk.integrations.sqlalchemy import SqlalchemyIntegration
 from apispec import APISpec
 from apispec.ext.marshmallow import MarshmallowPlugin
 from flask import Flask, g
@@ -21,12 +23,29 @@ from app.helpers.siren import SirenAPIClient
 from app.templates.filters import JINJA_CUSTOM_FILTERS
 from config import MOBILIC_ENV
 
+
+def _sentry_traces_sampler(sampling_context):
+    wsgi = sampling_context.get("wsgi_environ") or {}
+    path = wsgi.get("PATH_INFO", "")
+    if wsgi.get("REQUEST_METHOD") == "OPTIONS" or path in ("/", "/health"):
+        return 0.0
+    if wsgi.get("HTTP_X_CLIENT_ID"):
+        return float(os.environ.get("SENTRY_SAMPLE_RATE_THIRDPARTY", 0.3))
+    if path == "/graphql":
+        return float(os.environ.get("SENTRY_SAMPLE_RATE_GRAPHQL", 0.02))
+    return float(os.environ.get("SENTRY_SAMPLE_RATE", 0.05))
+
+
 sentry_sdk.init(
     dsn=os.environ.get("SENTRY_DSN"),
-    traces_sample_rate=os.environ.get("SENTRY_SAMPLE_RATE", 0),
+    traces_sampler=_sentry_traces_sampler,
     integrations=[
         LoggingIntegration(level=logging.INFO, event_level=logging.ERROR),
+        FlaskIntegration(),
+        SqlalchemyIntegration(),
     ],
+    environment=os.environ.get("SENTRY_ENVIRONMENT"),
+    send_default_pii=False,
 )
 app = Flask(__name__)
 

--- a/app/helpers/graphql.py
+++ b/app/helpers/graphql.py
@@ -162,6 +162,8 @@ class CustomGraphQLView(GraphQLView):
                     f"Could not add GraphQl request info to log context because of following error {e}"
                 )
         with configure_scope() as scope:
-            scope.set_transaction_name(operation_name)
+            # source="custom" raises priority above FlaskIntegration's
+            # "route" source -> the operation name actually sticks in Sentry.
+            scope.set_transaction_name(operation_name, source="custom")
             response = super().dispatch_request()
             return response

--- a/app/helpers/logging.py
+++ b/app/helpers/logging.py
@@ -10,7 +10,9 @@ from logging_ldp.formatters import LDPGELFFormatter
 from logging_ldp.handlers import LDPGELFTCPSocketHandler
 from logging_ldp.schemas import LDPSchema
 from marshmallow import fields
-from sentry_sdk import set_tag
+from sentry_sdk import set_tag, set_measurement
+from sqlalchemy import event
+from sqlalchemy.engine import Engine
 from werkzeug.exceptions import HTTPException
 
 from app import app
@@ -41,9 +43,11 @@ def _user_info():
         user=str(current_user),
         user_id=current_user.id if current_user else None,
         email=str(current_user.email if current_user else None),
-        metabase=f"https://metabase.mobilic.beta.gouv.fr/dashboard/6?id={current_user.id}"
-        if current_user
-        else None,
+        metabase=(
+            f"https://metabase.mobilic.beta.gouv.fr/dashboard/6?id={current_user.id}"
+            if current_user
+            else None
+        ),
     )
 
 
@@ -52,9 +56,11 @@ def _strip_unwanted_and_sensitive_fields_from_log_data(data):
         return data
     if type(data) is dict:
         return {
-            k: "***"
-            if k in SENSITIVE_FIELDS
-            else _strip_unwanted_and_sensitive_fields_from_log_data(v)
+            k: (
+                "***"
+                if k in SENSITIVE_FIELDS
+                else _strip_unwanted_and_sensitive_fields_from_log_data(v)
+            )
             for k, v in data.items()
             if k not in UNWANTED_FIELDS
         }
@@ -76,6 +82,33 @@ def _get_request_endpoint():
     if graphql_op_short:
         return f'{method_with_path} "{graphql_op_short}"'
     return method_with_path
+
+
+@event.listens_for(Engine, "before_cursor_execute")
+def _sql_perf_before(
+    conn, cursor, statement, parameters, context, executemany
+):
+    context._mobilic_sql_start = time()
+
+
+@event.listens_for(Engine, "after_cursor_execute")
+def _sql_perf_after(conn, cursor, statement, parameters, context, executemany):
+    if not has_request_context():
+        return
+    log_info = getattr(g, "log_info", None)
+    if not log_info:
+        return
+    start = getattr(context, "_mobilic_sql_start", None)
+    if start is None:
+        return
+    duration_ms = (time() - start) * 1000
+    log_info["sql_query_count"] = log_info.get("sql_query_count", 0) + 1
+    log_info["sql_total_time_ms"] = (
+        log_info.get("sql_total_time_ms", 0) + duration_ms
+    )
+    if duration_ms > log_info.get("sql_slowest_ms", 0):
+        log_info["sql_slowest_ms"] = round(duration_ms, 2)
+        log_info["sql_slowest_query"] = (statement or "")[:200]
 
 
 @app.before_request
@@ -104,6 +137,26 @@ def enrich_sentry_with_user_information():
         sentry_sdk.set_user(
             {"id": current_user.id, "email": current_user.email}
         )
+
+
+# set_measurement is the supported API on sentry-sdk 2.19 (current pin).
+# Deprecated in 2.28+ -> migrate to span attributes when upgrading to 3.x.
+def _push_sql_measurements_to_sentry(log_info, request_time_ms):
+    sql_total = log_info.get("sql_total_time_ms", 0)
+    sql_count = log_info.get("sql_query_count", 0)
+    sql_ratio = sql_total / request_time_ms if request_time_ms > 0 else 0
+    try:
+        set_measurement("sql.total_time", sql_total, "millisecond")
+        set_measurement("sql.query_count", sql_count, "none")
+        set_measurement("sql.ratio", sql_ratio, "ratio")
+        if log_info.get("sql_slowest_ms"):
+            set_measurement(
+                "sql.slowest_ms",
+                log_info["sql_slowest_ms"],
+                "millisecond",
+            )
+    except Exception:
+        pass
 
 
 @app.after_request
@@ -139,6 +192,8 @@ def log_request_info(response):
             except:
                 pass
             app.logger.error(BadGraphQLRequestError())
+
+        _push_sql_measurements_to_sentry(log_info, request_time)
 
         app.logger.info(
             log_message,


### PR DESCRIPTION
[Carte Trello](https://trello.com/c/HfpTFVik/2600-sentry-cr%C3%A9er-des-views-pour-faciliter-le-suivi-des-erreurs)

**Problème :**
Les éditeurs tiers ont régulièrement des timeouts sur l'API. Il faut confirmer si le ralentissement vient du serveur backend (CPU/RAM dyno) ou de la base de données,  afin de décider rationnellement s'il faut scaler le dyno Scalingo `mobilic-api` de L à XL.

**Solution :**
Cette PR ajoute l'instrumentation Sentry nécessaire pour alimenter les futurs dashboards et views (la création des views/dashboards eux-mêmes se fait dans l'UI Sentry, hors scope de cette PR).

- `FlaskIntegration` + `SqlalchemyIntegration` activées (transactions auto + sub-spans SQL natifs).
- `traces_sampler` différencié : 30 % sur le trafic tiers (`X-CLIENT-ID`), 2 % sur `/graphql` interne, 5 % ailleurs — pour booster l'échantillonnage là où on diagnostique sans cramer le quota Sentry.
- Compteurs par requête HTTP via SQLAlchemy event listeners : `sql_query_count`, `sql_total_time_ms`, `sql_slowest_ms`, et le ratio `sql.ratio = temps SQL / temps total` exposés comme measurements Sentry.
- Le ratio permettra de distinguer dans les dashboards une opération **DB-bound** (ratio > 0.7 → optimiser DB, scaler le dyno ne sert à rien) d'une opération **app-bound** (ratio < 0.3 + CPU dyno saturé → XL justifié).