### PR TITLE
fix(api): register snooze_nb_worker_info mutation

### DIFF
--- a/app/controllers/__init__.py
+++ b/app/controllers/__init__.py
@@ -305,6 +305,7 @@ class PrivateMutations(graphene.ObjectType):
     dismiss_company_token = DismissCompanyToken.Field()
     generate_company_token = GenerateCompanyToken.Field()
     snooze_certificate_info = SnoozeCertificateInfo.Field()
+    snooze_nb_worker_info = SnoozeNbWorkerInfo.Field()
     add_scenario_testing_result = AddScenarioTestingResult.Field()
     create_survey_action = CreateSurveyAction.Field()
     send_control_bulletin_email = SendControlBulletinEmail.Field()


### PR DESCRIPTION
https://trello.com/c/Dbnm55Kk/2678-erreur-lorsquon-refuse-de-renseigner-le-nombre-de-salari%C3%A9-%C3%A0-la-connexion?search_id=e9a56693-eb00-4ec9-ab38-fc7f7c66a19d