### PR TITLE
hotfix(webinars): use cache with redis and fallback if rate limit is reached

### DIFF
--- a/app/controllers/misc.py
+++ b/app/controllers/misc.py
@@ -1,16 +1,49 @@
+import json
+import logging
+
+import redis as redis_module
 from flask import jsonify
-from cachetools import cached, TTLCache
 
 from app import app
 from app.helpers.livestorm import livestorm, NoLivestormCredentialsError
 
-ttl_cache = TTLCache(maxsize=1, ttl=3600)
+logger = logging.getLogger(__name__)
+
+WEBINARS_CACHE_KEY = "livestorm:next_webinars"
+WEBINARS_CACHE_TTL = 3600
+
+_redis_client = None
+
+
+def _get_redis_client():
+    global _redis_client
+    if _redis_client is None:
+        _redis_client = redis_module.Redis.from_url(
+            app.config["CELERY_BROKER_URL"]
+        )
+    return _redis_client
 
 
 @app.route("/next-webinars", methods=["GET"])
-@cached(cache=ttl_cache)
 def get_webinars_list():
     if not app.config["LIVESTORM_API_TOKEN"]:
         raise NoLivestormCredentialsError()
+
+    try:
+        cached = _get_redis_client().get(WEBINARS_CACHE_KEY)
+        if cached:
+            return jsonify(json.loads(cached)), 200
+    except Exception:
+        logger.warning("Redis unavailable, skipping cache read for webinars")
+
     webinars = sorted(livestorm.get_next_webinars(), key=lambda w: w.time)
-    return jsonify([w._asdict() for w in webinars]), 200
+    webinars_data = [w._asdict() for w in webinars]
+
+    try:
+        _get_redis_client().setex(
+            WEBINARS_CACHE_KEY, WEBINARS_CACHE_TTL, json.dumps(webinars_data)
+        )
+    except Exception:
+        logger.warning("Redis unavailable, skipping cache write for webinars")
+
+    return jsonify(webinars_data), 200

--- a/app/helpers/errors.py
+++ b/app/helpers/errors.py
@@ -1,5 +1,5 @@
 from graphql import GraphQLError
-from abc import ABC, abstractmethod
+from abc import ABC
 from sqlalchemy.exc import IntegrityError
 import re
 
@@ -7,10 +7,7 @@ from app.helpers.time import to_timestamp
 
 
 class MobilicError(GraphQLError, ABC):
-    @property
-    @abstractmethod
-    def code(self):
-        pass
+    code: str
 
     http_status_code = 500
 

--- a/app/helpers/livestorm.py
+++ b/app/helpers/livestorm.py
@@ -40,12 +40,12 @@ STATIC_FALLBACK_WEBINARS = [
     LiveStormWebinar(
         title="Webinaire Mobilic à destination des gestionnaires",
         link="https://app.livestorm.co/mte/webinaire-comment-utiliser-mobilic-session-60",
-        time=1783414800,  # 7 juil. 2026 11:00 CEST
+        time=1783414800,  # Jul 7, 2026 11:00 CEST
     ),
     LiveStormWebinar(
         title="Webinaire Mobilic à destination des gestionnaires",
         link="https://app.livestorm.co/mte/webinaire-comment-utiliser-mobilic-session-60",
-        time=1784019600,  # 14 juil. 2026 11:00 CEST
+        time=1784019600,  # Jul 14, 2026 11:00 CEST
     ),
 ]
 

--- a/app/helpers/livestorm.py
+++ b/app/helpers/livestorm.py
@@ -40,12 +40,7 @@ STATIC_FALLBACK_WEBINARS = [
     LiveStormWebinar(
         title="Webinaire Mobilic à destination des gestionnaires",
         link="https://app.livestorm.co/mte/webinaire-comment-utiliser-mobilic-session-60",
-        time=1783414800,  # Jul 7, 2026 11:00 CEST
-    ),
-    LiveStormWebinar(
-        title="Webinaire Mobilic à destination des gestionnaires",
-        link="https://app.livestorm.co/mte/webinaire-comment-utiliser-mobilic-session-60",
-        time=1784019600,  # Jul 14, 2026 11:00 CEST
+        time=1787043600,  # Aug 18, 2026 11:00 CEST
     ),
 ]
 

--- a/app/helpers/livestorm.py
+++ b/app/helpers/livestorm.py
@@ -1,9 +1,13 @@
+import logging
+import time
 import requests
 import re
 from typing import NamedTuple
 
 from app import app
 from app.helpers.errors import MobilicError
+
+logger = logging.getLogger(__name__)
 
 
 class LiveStormWebinar(NamedTuple):
@@ -17,6 +21,11 @@ class LivestormRequestError(MobilicError):
     default_message = "Request to Livestorm API failed"
 
 
+class LivestormRateLimitError(MobilicError):
+    code = "LIVESTORM_RATE_LIMIT"
+    default_message = "Livestorm API monthly rate limit exceeded"
+
+
 class NoLivestormCredentialsError(MobilicError):
     code = "NO_LIVESTORM_CRENDENTIALS"
     default_message = "No Livestorm API credentials"
@@ -26,6 +35,19 @@ BASE_URL = "https://api.livestorm.co/v1"
 UPCOMING_SESSIONS_ENDPOINT = "/sessions?filter[status]=upcoming&include=event"
 MAX_PAGE_SIZE = 50
 MOBILIC_EVENT_TITLE_RE = re.compile(r"\bmobilic\b", flags=re.IGNORECASE)
+
+STATIC_FALLBACK_WEBINARS = [
+    LiveStormWebinar(
+        title="Webinaire Mobilic à destination des gestionnaires",
+        link="https://app.livestorm.co/mte/webinaire-comment-utiliser-mobilic-session-60",
+        time=1783414800,  # 7 juil. 2026 11:00 CEST
+    ),
+    LiveStormWebinar(
+        title="Webinaire Mobilic à destination des gestionnaires",
+        link="https://app.livestorm.co/mte/webinaire-comment-utiliser-mobilic-session-60",
+        time=1784019600,  # 14 juil. 2026 11:00 CEST
+    ),
+]
 
 
 # API reference : https://developers.livestorm.co/reference/get_ping
@@ -56,7 +78,11 @@ class LivestormAPIClient:
                 headers=headers,
                 **kwargs,
             )
+            if page_response.status_code == 429:
+                raise LivestormRateLimitError()
             return page_response.json()
+        except LivestormRateLimitError:
+            raise
         except Exception as e:
             raise LivestormRequestError(
                 f"Request to Livestorm API failed with error : {e}"
@@ -84,9 +110,17 @@ class LivestormAPIClient:
         return results
 
     def get_next_webinars(self):
-        upcoming_sessions_json = self._get_all_page_results(
-            UPCOMING_SESSIONS_ENDPOINT
-        )
+        try:
+            upcoming_sessions_json = self._get_all_page_results(
+                UPCOMING_SESSIONS_ENDPOINT
+            )
+        except LivestormRateLimitError:
+            logger.warning(
+                "Livestorm API monthly rate limit reached, returning static fallback webinars"
+            )
+            now = int(time.time())
+            return [w for w in STATIC_FALLBACK_WEBINARS if w.time > now]
+
         upcoming_sessions = upcoming_sessions_json["data"]
         associated_events = upcoming_sessions_json["included"]
 

--- a/app/tests/test_livestorm.py
+++ b/app/tests/test_livestorm.py
@@ -1,8 +1,8 @@
 import json
-from unittest.mock import patch
+from unittest.mock import patch, MagicMock
 
 from app import app
-from app.helpers.livestorm import livestorm
+from app.helpers.livestorm import livestorm, LivestormRateLimitError
 from app.tests import BaseTest
 
 
@@ -67,8 +67,19 @@ class TestLiveStormWebinars(BaseTest):
     @patch(
         "app.helpers.livestorm.LivestormAPIClient._request_page_and_get_results_and_page_count"
     )
-    def test_webinars_endpoint(self, mock):
+    @patch("app.controllers.misc._get_redis_client")
+    def test_webinars_endpoint(self, mock_redis_factory, mock):
         app.config["LIVESTORM_API_TOKEN"] = "abc"
+
+        class FakeRedis:
+            def get(self, key):
+                return None
+
+            def setex(self, key, ttl, value):
+                pass
+
+        mock_redis_factory.return_value = FakeRedis()
+
         with app.test_client() as c:
             mock.side_effect = (
                 lambda *args, **kwargs: generate_livestorm_response_payload(
@@ -82,8 +93,23 @@ class TestLiveStormWebinars(BaseTest):
     @patch(
         "app.helpers.livestorm.LivestormAPIClient._request_page_and_get_results_and_page_count"
     )
-    def test_webinars_endpoint_caches_livestorm_requests(self, mock):
+    @patch("app.controllers.misc._get_redis_client")
+    def test_webinars_endpoint_caches_livestorm_requests(
+        self, mock_redis_factory, mock
+    ):
         app.config["LIVESTORM_API_TOKEN"] = "abc"
+
+        redis_store = {}
+
+        class FakeRedis:
+            def get(self, key):
+                return redis_store.get(key)
+
+            def setex(self, key, ttl, value):
+                redis_store[key] = value
+
+        mock_redis_factory.return_value = FakeRedis()
+
         with app.test_client() as c:
             mock.side_effect = (
                 lambda *args, **kwargs: generate_livestorm_response_payload(
@@ -98,3 +124,57 @@ class TestLiveStormWebinars(BaseTest):
             webinars_response = c.get(MOBILIC_WEBINARS_ENDPOINT)
             mock.assert_not_called()
             self.assertEqual(len(webinars_response.json), 4)
+
+    @patch(
+        "app.helpers.livestorm.LivestormAPIClient._request_page_and_get_results_and_page_count"
+    )
+    @patch("app.controllers.misc._get_redis_client")
+    def test_webinars_endpoint_returns_fallback_on_rate_limit(
+        self, mock_redis_factory, mock
+    ):
+        app.config["LIVESTORM_API_TOKEN"] = "abc"
+        mock_redis_factory.return_value = MagicMock(
+            get=lambda k: None, setex=lambda k, t, v: None
+        )
+        mock.side_effect = LivestormRateLimitError()
+
+        with app.test_client() as c:
+            webinars_response = c.get(MOBILIC_WEBINARS_ENDPOINT)
+            self.assertEqual(webinars_response.status_code, 200)
+            self.assertGreater(len(webinars_response.json), 0)
+            for webinar in webinars_response.json:
+                self.assertIn("title", webinar)
+                self.assertIn("link", webinar)
+                self.assertIn("time", webinar)
+
+    @patch("app.helpers.livestorm.time")
+    @patch(
+        "app.helpers.livestorm.LivestormAPIClient._request_page_and_get_results_and_page_count"
+    )
+    def test_fallback_filters_past_sessions(self, mock_request, mock_time):
+        # Simulate being far in the future so all fallback sessions are in the past
+        mock_time.time.return_value = 9999999999
+        mock_request.side_effect = LivestormRateLimitError()
+
+        webinars = livestorm.get_next_webinars()
+        self.assertEqual(len(webinars), 0)
+
+    @patch(
+        "app.helpers.livestorm.LivestormAPIClient._request_page_and_get_results_and_page_count"
+    )
+    @patch("app.controllers.misc._get_redis_client")
+    def test_webinars_endpoint_works_when_redis_unavailable(
+        self, mock_redis_factory, mock
+    ):
+        app.config["LIVESTORM_API_TOKEN"] = "abc"
+        mock_redis_factory.side_effect = Exception("Redis connection failed")
+        mock.side_effect = (
+            lambda *args, **kwargs: generate_livestorm_response_payload(
+                1, "Présentation Mobilic"
+            )
+        )
+
+        with app.test_client() as c:
+            webinars_response = c.get(MOBILIC_WEBINARS_ENDPOINT)
+            self.assertEqual(webinars_response.status_code, 200)
+            self.assertEqual(len(webinars_response.json), 2)


### PR DESCRIPTION
https://trello.com/c/hD3o9Sde/2723-livestorm-corriger-les-erreurs-li%C3%A9es-au-d%C3%A9passement-de-quotas-de-calls-api