### PR TITLE
fix(brevo): sanitize deal name in identifier map to match lookup

### DIFF
--- a/app/services/brevo/orchestrator.py
+++ b/app/services/brevo/orchestrator.py
@@ -177,14 +177,9 @@ class BrevoSyncOrchestrator:
             existing_deals = self.brevo.get_existing_deals_by_pipeline(
                 pipeline_id
             )
-            deals_by_identifier = {}
-            for deal in existing_deals:
-                if deal.get("siret"):
-                    deals_by_identifier[f"siret_{deal['siret']}"] = deal
-                if deal.get("siren"):
-                    deals_by_identifier[f"siren_{deal['siren']}"] = deal
-                if not deal.get("siret") and not deal.get("siren"):
-                    deals_by_identifier[f"name_{deal['name']}"] = deal
+            deals_by_identifier = self._build_deals_by_identifier(
+                existing_deals
+            )
 
             batch_size = self.MAX_REQUESTS_PER_BATCH
             for i in range(0, len(companies_data), batch_size):
@@ -243,6 +238,23 @@ class BrevoSyncOrchestrator:
                 result.errors.append(error_msg)
 
         return result
+
+    def _build_deals_by_identifier(
+        self, existing_deals: List[Dict[str, Any]]
+    ) -> Dict[str, Dict[str, Any]]:
+        # Same sanitize on both sides (build + lookup) so name-keyed deals
+        # match even if the raw Brevo-stored name predates the current
+        # sanitize rules.
+        deals_by_identifier: Dict[str, Dict[str, Any]] = {}
+        for deal in existing_deals:
+            if deal.get("siret"):
+                deals_by_identifier[f"siret_{deal['siret']}"] = deal
+            if deal.get("siren"):
+                deals_by_identifier[f"siren_{deal['siren']}"] = deal
+            if not deal.get("siret") and not deal.get("siren"):
+                sanitized = self.brevo.sanitize_company_name(deal["name"])
+                deals_by_identifier[f"name_{sanitized}"] = deal
+        return deals_by_identifier
 
     def _find_existing_deal(
         self,

--- a/app/tests/test_brevo_deal_lookup.py
+++ b/app/tests/test_brevo_deal_lookup.py
@@ -1,0 +1,39 @@
+import unittest
+
+from app.helpers.brevo import BrevoApiClient
+from app.services.brevo.orchestrator import BrevoSyncOrchestrator
+
+
+class BrevoDealLookupSymmetryTestCase(unittest.TestCase):
+    """Regression: deals_by_identifier must sanitize the deal name so that
+    the map keys match what _find_existing_deal computes at lookup time.
+    Without this, deals created before a sanitize rule change (e.g. adding
+    U+2019) get re-duplicated on the next sync.
+    """
+
+    def setUp(self):
+        self.client = BrevoApiClient(api_key="test-key")
+        self.orchestrator = BrevoSyncOrchestrator(self.client)
+
+    def test_sanitize_strips_typographic_and_ascii_apostrophes(self):
+        for raw in ["TIA’FRET", "TIA'FRET", "Ruet’express"]:
+            with self.subTest(raw=raw):
+                self.assertNotIn("'", self.client.sanitize_company_name(raw))
+                self.assertNotIn("’", self.client.sanitize_company_name(raw))
+
+    def test_lookup_matches_deal_stored_with_typographic_apostrophe(self):
+        # A deal created before the sanitize change still has its raw
+        # typographic apostrophe in Brevo. The lookup uses the fresh DB
+        # name which the new sanitize normalizes. Both keys must align.
+        raw_brevo_name = "TIA’FRET"
+        deals_by_identifier = self.orchestrator._build_deals_by_identifier(
+            [{"id": "deal-1", "name": raw_brevo_name}]
+        )
+
+        existing, key = self.orchestrator._find_existing_deal(
+            {"company_name": raw_brevo_name}, deals_by_identifier
+        )
+
+        self.assertIsNotNone(existing)
+        self.assertEqual(existing["id"], "deal-1")
+        self.assertEqual(key, "name_TIA FRET")


### PR DESCRIPTION
https://trello.com/c/GVhJ0Lah

Suivi de la PR #752 : symétrise le mapping `deals_by_identifier` (build ↔ lookup) après l'ajout de U+2019 à la sanitize.

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>