### PR TITLE
perf(dashboard): cache _count_pending_validations in redis (5min TTL)

### DIFF
--- a/app/controllers/misc.py
+++ b/app/controllers/misc.py
@@ -1,29 +1,16 @@
 import json
 import logging
 
-import redis as redis_module
 from flask import jsonify
 
 from app import app
 from app.helpers.livestorm import livestorm, NoLivestormCredentialsError
+from app.helpers.redis import get_redis_client
 
 logger = logging.getLogger(__name__)
 
 WEBINARS_CACHE_KEY = "livestorm:next_webinars"
 WEBINARS_CACHE_TTL = 60 * 60 * 6
-
-_redis_client = None
-
-
-def _get_redis_client():
-    global _redis_client
-    if _redis_client is None:
-        _redis_client = redis_module.Redis.from_url(
-            app.config["CELERY_BROKER_URL"],
-            socket_connect_timeout=3,
-            socket_timeout=3,
-        )
-    return _redis_client
 
 
 def refresh_webinars_cache():
@@ -36,7 +23,7 @@ def refresh_webinars_cache():
         return
     webinars = sorted(livestorm.get_next_webinars(), key=lambda w: w.time)
     webinars_data = [w._asdict() for w in webinars]
-    _get_redis_client().setex(
+    get_redis_client().setex(
         WEBINARS_CACHE_KEY, WEBINARS_CACHE_TTL, json.dumps(webinars_data)
     )
 
@@ -47,7 +34,7 @@ def get_webinars_list():
         raise NoLivestormCredentialsError()
 
     try:
-        cached = _get_redis_client().get(WEBINARS_CACHE_KEY)
+        cached = get_redis_client().get(WEBINARS_CACHE_KEY)
         if cached:
             return jsonify(json.loads(cached)), 200
     except Exception:

--- a/app/domain/dashboard_summary.py
+++ b/app/domain/dashboard_summary.py
@@ -1,9 +1,11 @@
+import logging
 from datetime import datetime, time, timedelta, timezone
 
 from sqlalchemy import func, or_
 
 from app import db
 from app.data_access.dashboard_summary import DashboardSummary
+from app.helpers.redis import get_redis_client
 from app.helpers.time import from_tz
 from app.models import (
     Activity,
@@ -14,6 +16,7 @@ from app.models import (
 )
 from app.models.employment import EmploymentRequestValidationStatus
 
+logger = logging.getLogger(__name__)
 
 # Activities open for more than this many days are considered abnormal
 # (worker forgot to close their chronometer). Bounding the window lets
@@ -22,6 +25,24 @@ from app.models.employment import EmploymentRequestValidationStatus
 ACTIVE_MISSIONS_WINDOW_DAYS = 30
 
 PENDING_VALIDATIONS_WINDOW_DAYS = 31
+
+PENDING_VALIDATIONS_CACHE_KEY = "dashboard:pending_validations:{company_id}"
+PENDING_VALIDATIONS_CACHE_TTL = 5 * 60
+
+
+def _pending_validations_cache_key(company_id):
+    return PENDING_VALIDATIONS_CACHE_KEY.format(company_id=company_id)
+
+
+def invalidate_pending_validations_cache(company_id):
+    try:
+        get_redis_client().delete(_pending_validations_cache_key(company_id))
+    except Exception:
+        logger.warning(
+            "Redis unavailable, skipping cache invalidation for "
+            "pending validations (company_id=%s)",
+            company_id,
+        )
 
 
 def _today_window_for_user(user_timezone):
@@ -77,6 +98,31 @@ def _count_active_missions(company_id):
 
 
 def _count_pending_validations(company_id):
+    cache_key = _pending_validations_cache_key(company_id)
+    try:
+        cached = get_redis_client().get(cache_key)
+        if cached is not None:
+            return int(cached)
+    except Exception:
+        logger.warning(
+            "Redis unavailable, skipping cache read for pending "
+            "validations (company_id=%s)",
+            company_id,
+        )
+
+    count = _count_pending_validations_uncached(company_id)
+
+    try:
+        get_redis_client().setex(
+            cache_key, PENDING_VALIDATIONS_CACHE_TTL, count
+        )
+    except Exception:
+        pass
+
+    return count
+
+
+def _count_pending_validations_uncached(company_id):
     """Missions started in the last PENDING_VALIDATIONS_WINDOW_DAYS days
     that are ended for every user, validated by at least one worker, and
     not yet validated by an admin.

--- a/app/domain/validation.py
+++ b/app/domain/validation.py
@@ -1,6 +1,7 @@
 from datetime import datetime, timedelta
 
 from app import db
+from app.domain.dashboard_summary import invalidate_pending_validations_cache
 from app.domain.mission import (
     get_mission_start_and_end_from_activities,
     end_mission_for_user,
@@ -223,6 +224,7 @@ def _get_or_create_validation(
             context=sanitize_support_context(None),
         )
         db.session.add(validation)
+        invalidate_pending_validations_cache(mission.company_id)
         return validation
 
 

--- a/app/helpers/redis.py
+++ b/app/helpers/redis.py
@@ -1,0 +1,18 @@
+import redis as redis_module
+
+from app import app
+
+_redis_client = None
+
+
+def get_redis_client():
+    # 3s timeouts so Redis outages never block a web worker; callers must
+    # catch exceptions and fall back to their uncached path.
+    global _redis_client
+    if _redis_client is None:
+        _redis_client = redis_module.Redis.from_url(
+            app.config["CELERY_BROKER_URL"],
+            socket_connect_timeout=3,
+            socket_timeout=3,
+        )
+    return _redis_client

--- a/app/tests/test_dashboard_summary.py
+++ b/app/tests/test_dashboard_summary.py
@@ -1,6 +1,13 @@
 from datetime import datetime, date, time, timezone, timedelta
+from unittest.mock import patch, MagicMock
 
 from app import db
+from app.domain.dashboard_summary import (
+    PENDING_VALIDATIONS_CACHE_TTL,
+    _count_pending_validations,
+    _pending_validations_cache_key,
+    invalidate_pending_validations_cache,
+)
 from app.models import MissionEnd, MissionValidation
 from app.models.activity import ActivityType
 from app.models.employment import EmploymentRequestValidationStatus
@@ -368,3 +375,43 @@ class TestDashboardSummary(BaseTest):
         response = self._query(user=other_user)
         self.assertEqual(response.status_code, 200)
         self.assertIsNotNone(response.json.get("errors"))
+
+
+class TestPendingValidationsCache(BaseTest):
+    def setUp(self):
+        super().setUp()
+        self.company = CompanyFactory.create()
+
+    @patch("app.domain.dashboard_summary.get_redis_client")
+    def test_cache_hit_returns_cached_value(self, mock_redis_factory):
+        mock_redis_factory.return_value = MagicMock(get=lambda k: b"42")
+        self.assertEqual(_count_pending_validations(self.company.id), 42)
+
+    @patch("app.domain.dashboard_summary.get_redis_client")
+    def test_cache_miss_computes_and_stores(self, mock_redis_factory):
+        store = {}
+        mock_redis_factory.return_value = MagicMock(
+            get=lambda k: None,
+            setex=lambda k, t, v: store.__setitem__(k, (t, v)),
+        )
+        result = _count_pending_validations(self.company.id)
+        key = _pending_validations_cache_key(self.company.id)
+        self.assertIn(key, store)
+        self.assertEqual(store[key], (PENDING_VALIDATIONS_CACHE_TTL, result))
+
+    @patch("app.domain.dashboard_summary.get_redis_client")
+    def test_redis_down_falls_back_to_sql(self, mock_redis_factory):
+        mock_redis_factory.side_effect = Exception("Redis connection failed")
+        # empty company → 0, must not raise
+        self.assertEqual(_count_pending_validations(self.company.id), 0)
+
+    @patch("app.domain.dashboard_summary.get_redis_client")
+    def test_invalidation_deletes_cache_key(self, mock_redis_factory):
+        deleted = []
+        mock_redis_factory.return_value = MagicMock(
+            delete=lambda k: deleted.append(k),
+        )
+        invalidate_pending_validations_cache(self.company.id)
+        self.assertEqual(
+            deleted, [_pending_validations_cache_key(self.company.id)]
+        )

--- a/app/tests/test_livestorm.py
+++ b/app/tests/test_livestorm.py
@@ -68,7 +68,7 @@ class TestLiveStormWebinars(BaseTest):
     @patch(
         "app.helpers.livestorm.LivestormAPIClient._request_page_and_get_results_and_page_count"
     )
-    @patch("app.controllers.misc._get_redis_client")
+    @patch("app.controllers.misc.get_redis_client")
     def test_webinars_endpoint_reads_from_cache(
         self, mock_redis_factory, mock
     ):
@@ -83,7 +83,7 @@ class TestLiveStormWebinars(BaseTest):
         # the endpoint must never call Livestorm, it only reads the cache
         mock.assert_not_called()
 
-    @patch("app.controllers.misc._get_redis_client")
+    @patch("app.controllers.misc.get_redis_client")
     def test_webinars_endpoint_returns_empty_when_cache_cold(
         self, mock_redis_factory
     ):
@@ -98,7 +98,7 @@ class TestLiveStormWebinars(BaseTest):
     @patch(
         "app.helpers.livestorm.LivestormAPIClient._request_page_and_get_results_and_page_count"
     )
-    @patch("app.controllers.misc._get_redis_client")
+    @patch("app.controllers.misc.get_redis_client")
     def test_refresh_webinars_cache_writes_livestorm_data(
         self, mock_redis_factory, mock
     ):
@@ -121,7 +121,7 @@ class TestLiveStormWebinars(BaseTest):
     @patch(
         "app.helpers.livestorm.LivestormAPIClient._request_page_and_get_results_and_page_count"
     )
-    @patch("app.controllers.misc._get_redis_client")
+    @patch("app.controllers.misc.get_redis_client")
     def test_refresh_webinars_cache_writes_fallback_on_rate_limit(
         self, mock_redis_factory, mock
     ):
@@ -156,7 +156,7 @@ class TestLiveStormWebinars(BaseTest):
     @patch(
         "app.helpers.livestorm.LivestormAPIClient._request_page_and_get_results_and_page_count"
     )
-    @patch("app.controllers.misc._get_redis_client")
+    @patch("app.controllers.misc.get_redis_client")
     def test_webinars_endpoint_returns_empty_when_redis_unavailable(
         self, mock_redis_factory, mock
     ):


### PR DESCRIPTION
https://trello.com/c/lmVP3ag6