### PR TITLE
fix(anonymization): make inactive company criteria strict

### DIFF
--- a/app/services/anonymization/standalone/data_finder.py
+++ b/app/services/anonymization/standalone/data_finder.py
@@ -1,5 +1,5 @@
 from app import app, db
-from sqlalchemy import or_, text
+from sqlalchemy import and_, or_, text
 from typing import Iterator, Set, Tuple, Dict, List
 from datetime import datetime
 from app.services.anonymization.standalone.anonymization_executor import (
@@ -250,8 +250,11 @@ class DataFinder(AnonymizationExecutor):
         self, cutoff_date: datetime
     ) -> Tuple[Set[int], Set[int], Set[int]]:
         """Find inactive companies and their related data based on:
-        - All employments have end_date OR
+        - No live employment (all terminated or dismissed) AND
         - No missions since cutoff_date
+
+        The intersection keeps companies with still-attached employees out
+        of the anonymization scope, even without recent missions.
 
         Returns:
             Tuple containing:
@@ -266,7 +269,7 @@ class DataFinder(AnonymizationExecutor):
             self.find_inactive_companies_by_missions(cutoff_date)
         )
 
-        inactive_companies = companies_terminated_employment.union(
+        inactive_companies = companies_terminated_employment.intersection(
             companies_no_recent_missions
         )
 
@@ -306,10 +309,13 @@ class DataFinder(AnonymizationExecutor):
     def find_inactive_companies_by_employment(
         self, cutoff_date: datetime
     ) -> Set[int]:
+        # A live employment is neither terminated nor dismissed: with or_
+        # any terminated-but-not-dismissed employment (the normal case) kept
+        # its company "active" forever, making this criterion unreachable.
         active_companies = (
             db.session.query(Employment.company_id)
             .filter(
-                or_(
+                and_(
                     Employment.end_date.is_(None),
                     Employment.dismissed_at.is_(None),
                 )

--- a/app/services/anonymization/user_related/classifier.py
+++ b/app/services/anonymization/user_related/classifier.py
@@ -26,8 +26,10 @@ class UserClassifier:
             )
         )
 
+        # Intersection: a company with still-attached employees or recent
+        # missions is not inactive, so its admins stay out of scope.
         return tuple(
-            companies_without_active_employments.union(
+            companies_without_active_employments.intersection(
                 companies_no_recent_missions
             )
         )

--- a/app/tests/test_inactive_companies_classification.py
+++ b/app/tests/test_inactive_companies_classification.py
@@ -1,0 +1,87 @@
+from datetime import datetime, timedelta
+
+from app import db
+from app.models import Mission
+from app.seed.factories import CompanyFactory, UserFactory, EmploymentFactory
+from app.seed.helpers import AuthenticatedUserContext
+from app.services.anonymization.user_related.classifier import UserClassifier
+from app.tests import BaseTest
+
+
+class TestInactiveCompaniesClassification(BaseTest):
+    """
+    A company is inactive (anonymization scope) only if it has no live
+    employment AND no mission since the cutoff date. Companies keeping
+    attached employees or logging missions must stay out of scope.
+    """
+
+    def setUp(self):
+        super().setUp()
+        self.cutoff_date = datetime.now() - timedelta(days=1)
+        self.user = UserFactory.create()
+
+    def _make_old_company(self, siren):
+        company = CompanyFactory.create(
+            usual_name=f"Company {siren}", siren=siren
+        )
+        # Column defaults are set at insert time: age the row explicitly
+        db.session.execute(
+            "UPDATE company SET creation_time = :creation_time WHERE id = :id",
+            {
+                "creation_time": self.cutoff_date - timedelta(days=365),
+                "id": company.id,
+            },
+        )
+        return company
+
+    def _attach_employment(self, company, end_date=None):
+        return EmploymentFactory.create(
+            user=self.user,
+            company=company,
+            start_date=(datetime.now() - timedelta(days=730)).date(),
+            end_date=end_date,
+            has_admin_rights=False,
+            submitter=self.user,
+            validation_status="approved",
+            reception_time=datetime.now(),
+        )
+
+    def _log_recent_mission(self, company):
+        with AuthenticatedUserContext(user=self.user):
+            mission = Mission(
+                company=company,
+                creation_time=datetime.now(),
+                reception_time=datetime.now(),
+                submitter=self.user,
+            )
+            db.session.add(mission)
+            db.session.commit()
+
+    def _inactive_companies(self):
+        return set(UserClassifier(self.cutoff_date)._get_inactive_companies())
+
+    def test_company_with_only_ended_employments_is_inactive(self):
+        company = self._make_old_company("111111111")
+        self._attach_employment(
+            company, end_date=(datetime.now() - timedelta(days=30)).date()
+        )
+        db.session.commit()
+
+        self.assertIn(company.id, self._inactive_companies())
+
+    def test_company_with_live_employment_is_not_inactive(self):
+        company = self._make_old_company("222222222")
+        self._attach_employment(company, end_date=None)
+        db.session.commit()
+
+        self.assertNotIn(company.id, self._inactive_companies())
+
+    def test_company_with_recent_mission_is_not_inactive(self):
+        company = self._make_old_company("333333333")
+        self._attach_employment(
+            company, end_date=(datetime.now() - timedelta(days=30)).date()
+        )
+        db.session.commit()
+        self._log_recent_mission(company)
+
+        self.assertNotIn(company.id, self._inactive_companies())


### PR DESCRIPTION
- the employment criterion used or_, so any terminated-but-not-dismissed
  employment kept its company active forever (criterion matched 0
  company in prod)
- a live employment is end_date IS NULL AND dismissed_at IS NULL
- combine the two criteria with an intersection: companies keeping
  attached employees or logging recent missions stay out of the
  anonymization scope

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>